### PR TITLE
test _req invalid status code

### DIFF
--- a/ct-dApp/tests/test_hopr_node.py
+++ b/ct-dApp/tests/test_hopr_node.py
@@ -80,7 +80,6 @@ def test_req_returns_invalid_status_code(caplog) -> None:
 
 
     async def test_response(caplog) -> None:
-
             node = MockHoprNode("some_url", "some_api_key")
             endpoint = "/some_valid_endpoint"
             expected_url = node._get_url(endpoint)


### PR DESCRIPTION
Test that _req method returns the correct log error message when the status code is invalid.