### PR TITLE
use the Matplotlib non-interactive backend

### DIFF
--- a/ct-dApp/viz/__init__.py
+++ b/ct-dApp/viz/__init__.py
@@ -7,7 +7,9 @@ import statistics
 import numpy as np
 import datetime
 
-
+import matplotlib
+# use the Matplotlib non-interactive backend, which allows Matplotlib to run without a GUI
+matplotlib.use('Agg')
 
 def network_viz(graph: dict[str, dict[str, list[int]]], file_name: str):
     """


### PR DESCRIPTION
I got an error when creating the network visualization using the Matplotlib library. Specifically, the error message "RuntimeError: main thread is not in main loop" suggests that the Matplotlib GUI is being called from a non-main thread.

I fixed the issue by using the Matplotlib non-interactive backend, which allows Matplotlib to run without a GUI. Therefore, users can run the app without the requirement to have a matplotlip gui installed. 