### PR TITLE
removed rfc3986==1.5.0

### DIFF
--- a/ct-dApp/requirements.txt
+++ b/ct-dApp/requirements.txt
@@ -9,4 +9,3 @@ pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-env==0.8.1
 pytest-mock==3.10.0
-rfc3986==1.5.0


### PR DESCRIPTION
Removed rfc3986==1.5.0 after testing that uninstalling the package has no impact on running the app. 