### PR TITLE
update_gather_peers

### DIFF
--- a/ct-dApp/hopr_node.py
+++ b/ct-dApp/hopr_node.py
@@ -8,6 +8,7 @@ from hoprd import wrapper
 from http_req import Http_req
 from viz import network_viz
 
+# pylint: disable=logging-format-interpolation,consider-using-f-string
 
 log = logging.getLogger(__name__)
 
@@ -25,10 +26,10 @@ class HoprNode():
                         'Content-Type': 'application/json'}
         self.url     = url
         self.peer_id = None
-        
+
         # access the functionality of the hoprd python api
         self.hoprd_api = wrapper.HoprdAPI(api_url=url, api_token=key)
-    
+
         # Class that implements the functionallity of http requests
         self.http_req = Http_req()
 
@@ -129,6 +130,7 @@ class HoprNode():
         :returns: nothing; the set of connected peerIds is kept in self.peers.
         """
         status= "connected"
+        connection_quality= 1
 
         while self.started:
             # check that we are still connected
@@ -138,21 +140,18 @@ class HoprNode():
                 continue
 
             try:
-                response = await self.hoprd_api.peers()
+                response = await self.hoprd_api.peers(quality=connection_quality)
                 json_body = response.json()
                 if status in json_body:
-                    for p in json_body[status]:
-                        peer = p["peerId"]
-                        if peer not in self.peers:
-                            self.peers.add(peer)
-                            log.info("Found new peer {}".format(peer))
+                    for peer in json_body[status]:
+                        peer_id = peer["peerId"]
+                        if peer_id not in self.peers:
+                            self.peers.add(peer_id)
+                            log.info("Found new peer {}".format(peer_id))
                 await asyncio.sleep(5)
 
-            except requests.exceptions.ReadTimeout:
-                log.warning("No answer from peer {}".format(self.peer_id))
-
-            except Exception as e:
-                log.error("Could not get peers from {}: {}".format(self.hoprd_api.api_url, str(e)))
+            except Exception as exception:
+                log.error("Could not get peers from {}: {}".format(self.hoprd_api._api_url, str(exception)))
                 log.error(traceback.format_exc())
 
 


### PR DESCRIPTION
I updated the gather peers method: 

1. included a quality parameter into the hoprd python api: https://github.com/hoprnet/hoprd-api-python/pull/8
   Then I included this into the gather peers method which allows us to only ping peers that actually should be pingable in theory. You can insert any parameter from 0 to 1. The description is in the documentation of the api. 

2. removed the timeout exception raised by request since we do not use requests anymore. The exception is now handled internally by the api. 

3. did some improvements suggested by pylint
   
   