### PR TITLE
Removed pytesting specific files on github

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Test with pytest
         working-directory: incentive-app
         run: |
-          pytest
+          pytest -k "not api_helper.py and not db_connection.py"
 
   image:
     name: Build and push container image

--- a/incentive-app/tests/test_hoprd_api_helper.py
+++ b/incentive-app/tests/test_hoprd_api_helper.py
@@ -1,9 +1,6 @@
 import pytest
 from tools.hopr_api_helper import HoprdAPIHelper
 
-# We keep the option to skip the tests until the package httpx package conflict gets resolved. 
-pytest.skip(allow_module_level=True)
-
 
 @pytest.fixture
 def api_helper():

--- a/incentive-app/tests/test_hoprd_bad_api_helper.py
+++ b/incentive-app/tests/test_hoprd_bad_api_helper.py
@@ -1,9 +1,6 @@
 import pytest
 from tools.hopr_api_helper import HoprdAPIHelper
 
-# We keep the option to skip the tests until the package httpx package conflict gets resolved.
-pytest.skip(allow_module_level=True)
-
 
 @pytest.fixture
 def bad_api_helper():


### PR DESCRIPTION
I have found a way to remove programmatically the test files that requires a specific setup/environment, which Github does provide:
- `test_db_connection.py` requires a db on localhost (can be changed later)
- `test_*_api_helper.py` requires a pluto environment running.

