### PR TITLE
Added mocking methods when no HOPRd node connected

### DIFF
--- a/incentive-app/netwatcher/__main__.py
+++ b/incentive-app/netwatcher/__main__.py
@@ -42,7 +42,7 @@ def main():
     # start the node and run the event loop until the node stops
     try:
         if mock_mode:
-            loop.run_until_complete(nw.start_mock())
+            loop.run_until_complete(nw.mock_start())
         else:
             loop.run_until_complete(nw.start())
 


### PR DESCRIPTION
### Current situation
For now, the `NetWatcher` strongly relies on a HOPRd node. This is necessary for communicating with the network, but can turn into a problem when no node is available at start. An environment parameter is already required when running the `NetWatcher` to specify if it needs to connect to a HOPRd node, or if will run with mocked a HOPRd node. a `start_mock` method is also declared but not filled &rarr; no data can be sent to the `Aggregator`.

### What's new
4 new methods to mock the behaviour of a HOPRd node:
- `mock_gather_peers`: every 5min (300s) gathers a random amount (between 5 and 10) of peer among a list of 100 pre-generated peer ids
- `mock_ping_peers`: every 1min (60s) ping the gathered peers in a random order. A ping can result in :
    - 80% of the time a random value between 10ms and 100ms 
    - 20% of the time a `None` value to mock the incapacity of communicating to the node
- `mock_transmit_peers`: every 10min (600s) transmit the peer latency list to the `Aggregator`
- `mock_start`: run the above 3 methods indefinitely.

Resolves #160 