### PR TITLE
split reward computation from saving rewards as a csv

### DIFF
--- a/incentive-app/economic_handler/economic_handler.py
+++ b/incentive-app/economic_handler/economic_handler.py
@@ -347,11 +347,11 @@ class EconomicHandler(HOPRNode):
 
         return "expected_reward", dataset
 
-    def save_expected_reward_csv(self, dataset: dict) -> str:
+    def save_expected_reward_csv(self, dataset: dict) -> bool:
         """
         Saves the expected rewards dictionary as a CSV file
         :param: dataset (dict): A dictionary containing the dataset entries.
-        :returns: str: Confirmation message of successfull dataset save.
+        :returns: bool: No meaning except that it allows testing of the function.
         """
         timestamp = time.strftime("%Y%m%d%H%M%S")
         folder_name = "expected_rewards"
@@ -366,7 +366,7 @@ class EconomicHandler(HOPRNode):
         except OSError as e:
             log.error(f"Error occurred while creating the folder: {e}")
             log.error(traceback.format_exc())
-            return "expected_rewards_csv", {}
+            return False
 
         try:
             with open(file_path, "w", newline="") as csvfile:
@@ -378,10 +378,10 @@ class EconomicHandler(HOPRNode):
         except OSError as e:
             log.error(f"Error occurred while writing to the CSV file: {e}")
             log.error(traceback.format_exc())
-            return "expected_reward_csv", {}
+            return False
 
         log.info("CSV file saved successfully")
-        return "CSV file saved successfully"
+        return True
 
     async def start(self):
         """

--- a/incentive-app/tests/test_economic_handler.py
+++ b/incentive-app/tests/test_economic_handler.py
@@ -258,7 +258,7 @@ def test_save_expected_reward_csv_success(new_expected_merge_result):
     node = EconomicHandler("some_url", "some_api_key", "some_rpch_endpoint")
     result = node.save_expected_reward_csv(new_expected_merge_result)
 
-    assert result == "CSV file saved successfully"
+    assert result is True
 
 
 def test_save_expected_reward_csv_OSError_folder_creation(new_expected_merge_result):
@@ -271,7 +271,7 @@ def test_save_expected_reward_csv_OSError_folder_creation(new_expected_merge_res
         node = EconomicHandler("some_url", "some_api_key", "some_rpch_endpoint")
         result = node.save_expected_reward_csv(new_expected_merge_result)
 
-    assert result == ("expected_rewards_csv", {})
+    assert result is False
 
 
 def test_save_expected_reward_csv_OSError_writing_csv(new_expected_merge_result):
@@ -285,7 +285,7 @@ def test_save_expected_reward_csv_OSError_writing_csv(new_expected_merge_result)
             node = EconomicHandler("some_url", "some_api_key", "some_rpch_endpoint")
             result = node.save_expected_reward_csv(new_expected_merge_result)
 
-    assert result == ("expected_reward_csv", {})
+    assert result is False
 
 
 def test_probability_sum(mocked_model_parameters, expected_merge_result):


### PR DESCRIPTION
Closes #158 

1) I splitted the expected reward computation and saving functionality of expected rewards. 
2) Included the budget as a parameter into the csv file and made the column names of the csv file more informative 
3) Adjusted the existing test cases and created a new test for checking whether the csv file gets saved correctly. 

We still need to include the timestamps of the last readings of the "database", "subgraph", "topology endpoint" as information into the csv. This needs to be done at a later point in time as the "database" and the "subgraph" are currently mocked. 