### PR TITLE
Use the logger for the Netwatcher

### DIFF
--- a/incentive-app/netwatcher/__main__.py
+++ b/incentive-app/netwatcher/__main__.py
@@ -7,6 +7,8 @@ from tools.utils import _getlogger, envvar
 
 from .netwatcher import NetWatcher
 
+log = _getlogger()
+
 
 def stop(instance: NetWatcher, caught_signal: Signals):
     """
@@ -14,13 +16,12 @@ def stop(instance: NetWatcher, caught_signal: Signals):
     :param node: the HOPR node to stop
     :param caught_signal: the signal that triggered the stop
     """
-    print(f">>> Caught signal {caught_signal.name} <<<")
-    print(">>> Stopping ...")
+    log.info(f">>> Caught signal {caught_signal.name} <<<")
+    log.info(">>> Stopping ...")
     instance.stop()
 
 
 def main():
-    log = _getlogger()
     exit_code = ExitCode.OK
 
     try:


### PR DESCRIPTION
### Current situation
For now, the `NetWatcher` class handles errors, but does not log anything in the console. At best, it uses `print` to inform on what is going on.

### What's new
This PR integrate the usage of logging in the `NetWatcher` class and related files. One improvement is the usage of `log.exception("<message>")`. This method integrate automatically execution traceback, which avoids to have the `log.error(traceback.format_exc())` call.

Resolves #170 