### PR TITLE
Deployment hotfix

### DIFF
--- a/incentive-app/aggregator/__main__.py
+++ b/incentive-app/aggregator/__main__.py
@@ -19,8 +19,8 @@ def main():
         envvar("DB_PORT", int)
         host = envvar("API_HOST")
         port = envvar("API_PORT", int)
-    except ValueError as e:
-        log.error(e)
+    except ValueError:
+        log.exception("Error while loading environment variables")
         exit(1)
 
     loader = AppLoader(factory=partial(create_app))

--- a/incentive-app/aggregator_trigger/aggregator_trigger.py
+++ b/incentive-app/aggregator_trigger/aggregator_trigger.py
@@ -34,7 +34,7 @@ class AggregatorTrigger:
             log.exception("Error while sending request to aggregator")
             return False
         else:
-            log.info(response)
+            log.info(f"Response for `send_list`: {response}")
             return True
 
     def stop(self):
@@ -42,7 +42,7 @@ class AggregatorTrigger:
         Stops the tasks of this node
         """
         log.info("Stopping AggTrigger instance")
-        
+
         self.started = False
         for task in self.tasks:
             task.cancel()

--- a/incentive-app/netwatcher/netwatcher.py
+++ b/incentive-app/netwatcher/netwatcher.py
@@ -85,8 +85,8 @@ class NetWatcher(HOPRNode):
                 if response.status == 200:
                     log.info(f"Transmisted peers: {', '.join(short_list)}")
                     return True
-        except Exception as e:  # ClientConnectorError
-            log.error(f"Error transmitting peers: {e}")
+        except Exception:  # ClientConnectorError
+            log.exception("Error transmitting peers")
 
         return False
 

--- a/incentive-app/tools/decorator.py
+++ b/incentive-app/tools/decorator.py
@@ -32,7 +32,7 @@ def wakeupcall(
         try:
             next_time = min_date + round((dt - min_date) / delta + 0.5) * delta
         except ZeroDivisionError:
-            log.error("Next sleep is 0 seconds..")
+            log.exception("Next sleep is 0 seconds..")
             return 1
 
         delay = int((next_time - dt).total_seconds())

--- a/incentive-app/tools/hopr_api_helper.py
+++ b/incentive-app/tools/hopr_api_helper.py
@@ -176,8 +176,8 @@ class HoprdAPIHelper:
 
         try:
             response = await self._safe_call(method, *args)
-        except httpx.HTTPError as e:
-            log.error(f"Error getting tickets in channel: {e}")
+        except httpx.HTTPError:
+            log.exception("Error getting tickets in channel")
             return None
         else:
             return response.json()
@@ -243,8 +243,8 @@ class HoprdAPIHelper:
 
         try:
             response = await self._safe_call(method, **kwargs)
-        except httpx.HTTPError as e:
-            log.error(f"Could not get peers from {self.url}: {e}")
+        except httpx.HTTPError:
+            log.exception(f"Could not get peers from {self.url}")
             return None
         else:
             json_body = response.json()


### PR DESCRIPTION
This PR is a hot fix correcting:
- the used decorator for delaying tasks: some tasks were still using `wakeupcall` which is slower to trigger the first time (hard for testing). It has been replaced with `formalin` with the same delays.
- some logs were missing in the `AggTrigger`