### PR TITLE
subgraph functionality implementation

### DIFF
--- a/incentive-app/economic_handler/__main__.py
+++ b/incentive-app/economic_handler/__main__.py
@@ -14,8 +14,16 @@ from .utils_econhandler import stop_instance
 @click.option("--apihost", default=None, help="IP-address of the API host")
 @click.option("--apikey", default=None, help="API key of the API host")
 @click.option("--rcphnodes", default=None, help="API endpoint for RPCh nodes")
-@click.option("--subgraphkey", default=None, help="API key of the subgraph")
-def main(port: str, apihost: str, apikey: str, rcphnodes: str, subgraphkey: str):
+@click.option("--subgraphurl", default=None, help="API key of the subgraph")
+@click.option("--scaddress", default=None, help="Address of the staking season")
+def main(
+    port: str,
+    apihost: str,
+    apikey: str,
+    rcphnodes: str,
+    subgraphurl: str,
+    scaddress: str,
+):
     """main"""
     log = _getlogger()
 
@@ -31,14 +39,21 @@ def main(port: str, apihost: str, apikey: str, rcphnodes: str, subgraphkey: str)
     if not rcphnodes:
         log.error("Endpoint for RPCh nodes not specified (use --rcphnodes)")
         exit()
-    if not subgraphkey:
+    if not subgraphurl:
         log.error("API key not specified (use --subgraphkey)")
+        exit()
+    if not scaddress:
+        log.error("SC address not specified (use --scaddress)")
         exit()
 
     exit_code = ExitCode.OK
 
     economic_handler = EconomicHandler(
-        f"http://{apihost}:{port}", apikey, rcphnodes, subgraphkey
+        f"http://{apihost}:{port}",
+        apikey,
+        rcphnodes,
+        subgraphurl,
+        scaddress,
     )
 
     loop = asyncio.new_event_loop()

--- a/incentive-app/run.sh
+++ b/incentive-app/run.sh
@@ -16,7 +16,8 @@ route=
 key=
 aggpost=
 rcphendpoint=
-subgraphkey=
+subgraphurl=
+scaddress=
 db=
 dbhost=
 dbuser=
@@ -81,12 +82,20 @@ while :; do
                 die 'ERROR: "--rcphendpoint" requires a non-empty option argument.'
             fi
             ;;
-        --subgraphkey)
+        --subgraphurl)
             if [ "$2" ]; then
-                subgraphkey=$2
+                subgraphurl=$2
                 shift
             else
-                die 'ERROR: "--subgraphkey" requires a non-empty option argument.'
+                die 'ERROR: "--subgraphurl" requires a non-empty option argument.'
+            fi
+            ;;
+        --scaddress)
+            if [ "$2" ]; then
+                scaddress=$2
+                shift
+            else
+                die 'ERROR: "--scaddress" requires a non-empty option argument.'
             fi
             ;;
         --db)
@@ -233,14 +242,18 @@ elif [ "$module" = "economic_handler" ]; then
         echo "Error: --rcphendpoint parameter is required"
         exit 1
     fi
-    if [ -z "$subgraphkey" ]; then
-        echo "Error: --subgraphkey parameter is required"
+    if [ -z "$subgraphurl" ]; then
+        echo "Error: --subgraphurl parameter is required"
+        exit 1
+    fi
+    if [ -z "$scaddress" ]; then
+        echo "Error: --scaddress parameter is required"
         exit 1
     fi
 
     clear
     echobold "Running Economic Handler"
-    python -m economic_handler  --port $port --apihost $host --apikey $key --rcphnodes $rcphendpoint --subgraphkey $subgraphkey
+    python -m economic_handler  --port $port --apihost $host --apikey $key --rcphnodes $rcphendpoint --subgraphurl $subgraphurl --scaddress $scaddress
 
 else
     echobold "Tried to run unknown module: '$module'"

--- a/incentive-app/tests/test_economic_handler.py
+++ b/incentive-app/tests/test_economic_handler.py
@@ -58,7 +58,11 @@ async def test_read_parameters_and_equations(mock_open_file, file_contents):
     mock_file.read.return_value = json.dumps(file_contents)
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     result = await node.read_parameters_and_equations(mock_file)
@@ -75,7 +79,11 @@ async def test_read_parameters_and_equations_file_not_found():
     """
     file_name = "non_existent_file.json"
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     result = await node.read_parameters_and_equations(file_name)
@@ -94,7 +102,11 @@ async def test_read_parameters_and_equations_check_values(
     mock_file.read.return_value = json.dumps(file_contents)
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     result = await node.read_parameters_and_equations(mock_file)
@@ -173,7 +185,11 @@ def test_merge_topology_metricdb_subgraph(merge_data, expected_merge_result):
     expected_result = expected_merge_result
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     result = node.merge_topology_metricdb_subgraph(
         unique_peerId_address, new_metrics_dict, new_subgraph_dict
@@ -191,7 +207,11 @@ def test_merge_topology_metricdb_subgraph_exception(merge_data):
     new_subgraph_dict = {}
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     result = node.merge_topology_metricdb_subgraph(
@@ -214,7 +234,11 @@ def test_block_rpch_nodes(mock_rpch_nodes_blacklist, expected_merge_result):
     """
     expected_peer_ids_in_result = {"peer_id_1", "peer_id_2", "peer_id_3"}
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     _, result = node.block_rpch_nodes(mock_rpch_nodes_blacklist, expected_merge_result)
@@ -273,7 +297,11 @@ def test_safe_address_split_stake(expected_merge_result, expected_split_stake_re
     print(expected_result)
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     result = node.safe_address_split_stake(expected_merge_result)
     print(result)
@@ -330,7 +358,11 @@ def test_compute_expected_reward(
     """
     budget = mocked_model_parameters["budget"]
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     result = node.compute_expected_reward(new_expected_split_stake_result, budget)
 
@@ -348,7 +380,11 @@ def test_save_expected_reward_csv_success(new_expected_split_stake_result):
     message in case of no errors.
     """
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     result = node.save_expected_reward_csv(new_expected_split_stake_result)
 
@@ -365,7 +401,11 @@ def test_save_expected_reward_csv_OSError_folder_creation(
     with patch("os.makedirs") as mock_makedirs:
         mock_makedirs.side_effect = OSError("Mocked OSError")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = node.save_expected_reward_csv(new_expected_split_stake_result)
 
@@ -381,7 +421,11 @@ def test_save_expected_reward_csv_OSError_writing_csv(new_expected_split_stake_r
         with patch("builtins.open") as mock_open:
             mock_open.side_effect = OSError("Mocked OSError")
             node = EconomicHandler(
-                "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+                "some_url",
+                "some_api_key",
+                "some_rpch_endpoint",
+                "some_subgraph_url",
+                "some_sc_address",
             )
             result = node.save_expected_reward_csv(new_expected_split_stake_result)
 
@@ -399,7 +443,11 @@ def test_probability_sum(mocked_model_parameters, expected_split_stake_result):
     merged_result = expected_split_stake_result
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     result = node.compute_ct_prob(parameters, equations, merged_result)
     sum_probabilities = sum(result[1][key]["prob"] for key in result[1])
@@ -418,7 +466,11 @@ def test_ct_prob_exception(mocked_model_parameters):
     merged_result = {}
 
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     result = node.compute_ct_prob(parameters, equations, merged_result)
@@ -436,7 +488,11 @@ def mock_node_for_test_start(mocker):
     mocker.patch.object(EconomicHandler, "scheduler", return_value=None)
 
     return EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
 
@@ -461,7 +517,11 @@ def test_stop():
     """
     mocked_task = MagicMock()
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
     node.tasks = {mocked_task}
 

--- a/incentive-app/tests/test_other_endpoints.py
+++ b/incentive-app/tests/test_other_endpoints.py
@@ -23,7 +23,11 @@ async def test_blacklist_rpch_nodes():
         mock_response.json.return_value = mock_response_data
 
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
 
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
@@ -41,7 +45,11 @@ async def test_blacklist_rpch_nodes_exceptions():
         # Simulate ClientError
         mock_get.side_effect = aiohttp.ClientError("ClientError")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
         assert result == ("rpch", [])
@@ -49,7 +57,11 @@ async def test_blacklist_rpch_nodes_exceptions():
         # Simulate ValueError
         mock_get.side_effect = ValueError("ValueError")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
         assert result == ("rpch", [])
@@ -57,7 +69,11 @@ async def test_blacklist_rpch_nodes_exceptions():
         # Simulate general exception
         mock_get.side_effect = Exception("Exception")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
         assert result == ("rpch", [])
@@ -103,11 +119,15 @@ async def test_get_staking_participations():
         mock_response.json.return_value = mock_response_data
 
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
 
         result = await node.get_staking_participations(
-            "some_api_key", "some_subgraph_id", "some_staking_season_address", 100
+            "some_subgraph_url", "some_staking_season_address", 100
         )
 
         assert result == (
@@ -129,29 +149,41 @@ async def test_get_staking_participations_exceptions():
         # Simulate ClientError
         mock_post.side_effect = aiohttp.ClientError("ClientError")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.get_staking_participations(
-            "some_api_key", "some_subgraph_id", "some_staking_season_address", 100
+            "some_subgraph_url", "some_staking_season_address", 100
         )
         assert result == ("subgraph_data", {})
 
         # Simulate ValueError
         mock_post.side_effect = ValueError("ValueError")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.get_staking_participations(
-            "some_api_key", "some_subgraph_id", "some_staking_season_address", 100
+            "some_subgraph_url", "some_staking_season_address", 100
         )
         assert result == ("subgraph_data", {})
 
         # Simulate general exception
         mock_post.side_effect = Exception("Exception")
         node = EconomicHandler(
-            "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
         )
         result = await node.get_staking_participations(
-            "some_api_key", "some_subgraph_id", "some_staking_season_address", 100
+            "some_subgraph_url", "some_staking_season_address", 100
         )
         assert result == ("subgraph_data", {})

--- a/incentive-app/tests/test_utils_econhandler.py
+++ b/incentive-app/tests/test_utils_econhandler.py
@@ -11,7 +11,11 @@ def test_stop_instance():
     with the SIGINT signal.
     """
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_key"
+        "some_url",
+        "some_api_key",
+        "some_rpch_endpoint",
+        "some_subgraph_url",
+        "some_sc_address",
     )
 
     # Create a mock object of the stop method of the EconomicHandler class


### PR DESCRIPTION
Resolves #185

1) I included new functionality to query a smart contract deployed on gnosis chain through a subgraph using The Graph API. As the safe smart contract and the corresponding subgraph are not available yet, I implement the functionality using the "HOPR Stake all seasons" subgraph: [link](https://thegraph.com/explorer/subgraphs/DrkbaCvNGVcNH1RghepLRy6NSHFi8Dmwp4T2LN3LqcjY). The subgraph returns a set of staking addresses and their corresponding stake in staking season 7. This information is similar to the information we expect to get from the safe smart contract and, therefore, we are able to impelment all the functionality alredy. 

2) I wrote unittest to test the new functionality 

### Important 
The query limit for a graph ql query using The Graph API is 1000, which implies that we cannot accomodate a network with more than 1000 nodes. Therefore, we need to do recursive calls to deal with a network of more than 1000 nodes. There are multiple ways to do it and I choose the following way:  

I use an async while True loop to iteratively fetch data in chunks of 1000 and the loop continues until there is no more data to fetch. I choose this approach as it provides better control over the flow and asyncronous nature of the code.

I tried to avoid an approach where I make recursive asynchronous calls because:
- Asynchronous recursion can lead to increased memory consumption
- Harder to read and maintain.