### PR TITLE
budget splitting rule for automatic and airdrop mode

### DIFF
--- a/incentive-app/economic_handler/economic_handler.py
+++ b/incentive-app/economic_handler/economic_handler.py
@@ -508,17 +508,23 @@ class EconomicHandler(HOPRNode):
         """
         budget = budget_param["budget"]["value"]
         budget_split_ratio = budget_param["s"]["value"]
+        dist_freq = budget_param["dist_freq"]["value"]
 
         for entry in dataset.values():
             entry["budget"] = budget
             entry["budget_split_ratio"] = budget_split_ratio
+            entry["distribution_frequency"] = dist_freq
 
             total_exp_reward = entry["prob"] * budget
+            protocol_exp_reward = total_exp_reward * budget_split_ratio
+
             entry["total_expected_reward"] = total_exp_reward
-            entry["protocol_exp_reward"] = total_exp_reward * budget_split_ratio
             entry["airdrop_expected_reward"] = total_exp_reward * (
                 1 - budget_split_ratio
             )
+            entry["protocol_exp_reward"] = protocol_exp_reward
+
+            entry["protocol_exp_reward_per_dist"] = protocol_exp_reward / dist_freq
 
         return "expected_reward", dataset
 

--- a/incentive-app/economic_handler/parameters.json
+++ b/incentive-app/economic_handler/parameters.json
@@ -32,9 +32,17 @@
       "value": 100,
       "comment": "budget for the given distribution period"
     },
+    "budget_period": {
+      "value": 15,
+      "comment": "budget period in seconds"
+    },
     "s": {
       "value": 0.25,
       "comment": "split ratio between automated and airdrop mode"
+    },
+    "dist_freq": {
+      "value": 2,
+      "comment": "distribution frequency of rewards via the automatic distribution"
     }
   }
 }

--- a/incentive-app/economic_handler/parameters_schema.py
+++ b/incentive-app/economic_handler/parameters_schema.py
@@ -38,6 +38,14 @@ schema = {
                     },
                     "required": ["value"],
                 },
+                "budget_period": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number", "minimum": 10},
+                        "comment": {"type": "string"},
+                    },
+                    "required": ["value"],
+                },
                 "s": {
                     "type": "object",
                     "properties": {
@@ -46,8 +54,16 @@ schema = {
                     },
                     "required": ["value"],
                 },
+                "dist_freq": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number", "minimum": 1},
+                        "comment": {"type": "string"},
+                    },
+                    "required": ["value"],
+                },
             },
-            "required": ["budget", "s"],
+            "required": ["budget", "budget_period", "s", "dist_freq"],
         },
     },
     "required": ["parameters", "equations", "budget_param"],

--- a/incentive-app/tests/test_economic_handler.py
+++ b/incentive-app/tests/test_economic_handler.py
@@ -335,9 +335,14 @@ def mocked_model_parameters():
                 "value": 100,
                 "comment": "budget for the given distribution period",
             },
+            "budget_period": {"value": 15, "comment": "budget period in seconds"},
             "s": {
                 "value": 0.25,
                 "comment": "split ratio between automated and airdrop mode",
+            },
+            "dist_freq": {
+                "value": 2,
+                "comment": "distribution frequency of rewards via the automatic distribution",
             },
         },
     }


### PR DESCRIPTION
Partly Resolves #194 

For more context read #194 

1. I decided to include the budget splitting rule between automatic token distribution and the airdrop token distribution in the expected reward calculation method. The rational is that this is the first time the split must be performed. Furthermore, the csv file should contain all this information for ex-post verification of the reward calculation.
2. The compute_expected_reward method splits the protocol expectd reward (due to the automatic distribution) further into smaller pieces. The size of each piece is determined by a parameter called 'dist_freq' (distribution frequency). The parmeter determines how much of the automatic distribution share should be distributed at each time step. 

### TODO
Use the 'dist_freq' parameter and the  'budget_period' parameter to calculate the time delay of a new "wakeupcall" decorator. The time delay is equal to budget_period (sec) divided by the distribution frequency.
  