### PR TITLE
Switch to new hoprd api structure

### DIFF
--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -10,4 +10,5 @@ Requests==2.31.0
 sanic==23.3.0
 validators==0.20.0
 sanic_testing==23.3.0
+celery==5.2.2
 # sanic[test]==23.3.0

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,4 +1,4 @@
-hoprd @ git+https://github.com/hoprnet/hoprd-sdk-python.git@main
+git+https://github.com/hoprnet/hoprd-sdk-python.git@main
 aiohttp==3.8.4
 jsonschema==4.17.3
 numpy==1.25.0

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,6 +1,5 @@
-hoprd @ git+https://github.com/jeandemeusy/hoprd-api-python.git@api-httpx-v0-23-3
+hoprd @ git+https://github.com/hoprnet/hoprd-sdk-python.git@main
 aiohttp==3.8.4
-click==8.1.3
 jsonschema==4.17.3
 numpy==1.25.0
 psycopg2_binary==2.9.6
@@ -10,11 +9,5 @@ pytest-asyncio==0.21.0
 Requests==2.31.0
 sanic==23.3.0
 validators==0.20.0
-httpx==0.23.3
 sanic_testing==23.3.0
 # sanic[test]==23.3.0
-
-
-# for hoprd package: here we use the latest WORKING version of the package. If you want
-# the latest release, use :
-# hoprd @ git+https://github.com/hoprnet/hoprd-api-python.git@main

--- a/ct-app/tests/test_hoprd_api_helper.py
+++ b/ct-app/tests/test_hoprd_api_helper.py
@@ -8,34 +8,12 @@ def api_helper():
     This fixture returns an instance of the HoprdAPIHelper class.
     """
     apihost = "localhost"
-    port = "13301"
+    port = "13304"
     apikey = "%th1s-IS-a-S3CR3T-ap1-PUSHING-b1ts-TO-you%"
 
     helper = HoprdAPIHelper(f"http://{apihost}:{port}", apikey)
 
     yield helper
-
-
-@pytest.mark.asyncio
-async def test_withdraw(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the withdraw method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    pass
-
-
-@pytest.mark.asyncio
-async def test_balance(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the balance method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    balance = await api_helper.balance()
-
-    assert balance is not None
-    assert "native" in balance
-    assert "hopr" in balance
 
 
 @pytest.mark.asyncio
@@ -51,45 +29,6 @@ async def test_balance_native(api_helper: HoprdAPIHelper):
 
 
 @pytest.mark.asyncio
-async def test_set_alias(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the set_alias method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    pass
-
-
-@pytest.mark.asyncio
-async def test_get_alias(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the get_alias method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    pass
-
-
-@pytest.mark.asyncio
-async def test_remove_alias(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the remove_alias method of the HoprdAPIHelper class returns
-    the expected response.
-    """
-    pass
-
-
-@pytest.mark.asyncio
-async def test_get_settings(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the get_settings method of the HoprdAPIHelper class returns
-    the expected response.
-    """
-    settings = await api_helper.get_settings()
-
-    assert settings is not None
-    assert isinstance(settings, dict)
-
-
-@pytest.mark.asyncio
 async def test_get_all_channels(api_helper: HoprdAPIHelper):
     """
     This test checks that the get_all_channels method of the HoprdAPIHelper class returns
@@ -99,39 +38,12 @@ async def test_get_all_channels(api_helper: HoprdAPIHelper):
 
 
 @pytest.mark.asyncio
-async def test_get_tickets_in_channel(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the get_tickets_in_channel method of the HoprdAPIHelper class
-    returns the expected response.
-    """
-    await api_helper.get_tickets_in_channel(True)
-
-
-@pytest.mark.asyncio
-async def test_redeem_tickets_in_channel(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the redeem_tickets_in_channel method of the HoprdAPIHelper
-    class returns the expected response.
-    """
-    pass
-
-
-@pytest.mark.asyncio
-async def test_redeem_tickets(api_helper: HoprdAPIHelper):
-    """
-    This test checks that the redeem_tickets method of the HoprdAPIHelper class returns
-    the expected response.
-    """
-    await api_helper.redeem_tickets()
-
-
-@pytest.mark.asyncio
 async def test_ping(api_helper: HoprdAPIHelper):
     """
     This test checks that the ping method of the HoprdAPIHelper class returns the
     expected response.
     """
-    peer_ids: list = await api_helper.peers("peerId")
+    peer_ids: list = await api_helper.peers("peer_id")
     latency = await api_helper.ping(peer_ids.pop())
 
     assert latency is not None
@@ -144,7 +56,7 @@ async def test_ping_bad_metric(api_helper: HoprdAPIHelper):
     This test checks that the ping method of the HoprdAPIHelper class returns the
     expected response when the peerId does not exist.
     """
-    peer_ids: list = await api_helper.peers("peerId")
+    peer_ids: list = await api_helper.peers("peer_id")
     latency = await api_helper.ping(peer_ids.pop(), metric="some_param")
 
     assert latency is None
@@ -156,7 +68,7 @@ async def test_peers(api_helper: HoprdAPIHelper):
     This test checks that the peers method of the HoprdAPIHelper class returns the
     expected response.
     """
-    peer_ids = await api_helper.peers("peerId")
+    peer_ids = await api_helper.peers("peer_id")
 
     assert peer_ids is not None
     assert isinstance(peer_ids, list)

--- a/ct-app/tests/test_hoprd_bad_api_helper.py
+++ b/ct-app/tests/test_hoprd_bad_api_helper.py
@@ -63,55 +63,12 @@ async def test_remove_alias(bad_api_helper: HoprdAPIHelper):
 
 
 @pytest.mark.asyncio
-async def test_get_settings(bad_api_helper: HoprdAPIHelper):
-    """
-    This test checks that the get_settings method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    result = await bad_api_helper.get_settings()
-
-    assert result is None
-
-
-@pytest.mark.asyncio
 async def test_get_all_channels(bad_api_helper: HoprdAPIHelper):
     """
     This test checks that the get_all_channels method of the HoprdAPIHelper class returns the
     expected response.
     """
     result = await bad_api_helper.get_all_channels(True)
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_get_tickets_in_channel(bad_api_helper: HoprdAPIHelper):
-    """
-    This test checks that the get_tickets_in_channel method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    result = await bad_api_helper.get_tickets_in_channel(True)
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_redeem_tickets_in_channel(bad_api_helper: HoprdAPIHelper):
-    """
-    This test checks that the redeem_tickets_in_channel method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-
-    pass
-
-
-@pytest.mark.asyncio
-async def test_redeem_tickets(bad_api_helper: HoprdAPIHelper):
-    """
-    This test checks that the redeem_tickets method of the HoprdAPIHelper class returns the
-    expected response.
-    """
-    result = await bad_api_helper.redeem_tickets()
 
     assert result is None
 

--- a/ct-app/tests/test_netwatcher.py
+++ b/ct-app/tests/test_netwatcher.py
@@ -31,7 +31,8 @@ def FakeNetWatcher() -> NetWatcher:
     return NetWatcher("some_url", "some_key", "some_posturl", "some_balanceurl", 10)
 
 
-def test__post_list():
+@pytest.mark.asyncio
+async def test__post_list():
     """
     Test that the method _post_list works.
     """
@@ -39,7 +40,7 @@ def test__post_list():
     instance.peers = ["some_peer", "some_other_peer"]
     instance.latency = {"some_peer": [10, 20], "some_other_peer": [30, 40]}
 
-    instance._post_list(MagicMock())
+    await instance._post_list(MagicMock())
 
     assert len(instance.peers) == 2
     assert len(instance.latency) == 2

--- a/ct-app/tests/test_other_endpoints.py
+++ b/ct-app/tests/test_other_endpoints.py
@@ -54,29 +54,29 @@ async def test_blacklist_rpch_nodes_exceptions():
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
         assert result == ("rpch", [])
 
-        # # Simulate ValueError
-        # mock_get.side_effect = OSError("ValueError")
-        # node = EconomicHandler(
-        #     "some_url",
-        #     "some_api_key",
-        #     "some_rpch_endpoint",
-        #     "some_subgraph_url",
-        #     "some_sc_address",
-        # )
-        # result = await node.blacklist_rpch_nodes("some_api_endpoint")
-        # assert result == ("rpch", [])
+        # Simulate ValueError
+        mock_get.side_effect = OSError("ValueError")
+        node = EconomicHandler(
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
+        )
+        result = await node.blacklist_rpch_nodes("some_api_endpoint")
+        assert result == ("rpch", [])
 
-        # # Simulate general exception
-        # mock_get.side_effect = Exception("Exception")
-        # node = EconomicHandler(
-        #     "some_url",
-        #     "some_api_key",
-        #     "some_rpch_endpoint",
-        #     "some_subgraph_url",
-        #     "some_sc_address",
-        # )
-        # result = await node.blacklist_rpch_nodes("some_api_endpoint")
-        # assert result == ("rpch", [])
+        # Simulate general exception
+        mock_get.side_effect = Exception("Exception")
+        node = EconomicHandler(
+            "some_url",
+            "some_api_key",
+            "some_rpch_endpoint",
+            "some_subgraph_url",
+            "some_sc_address",
+        )
+        result = await node.blacklist_rpch_nodes("some_api_endpoint")
+        assert result == ("rpch", [])
 
 
 @pytest.mark.asyncio

--- a/ct-app/tests/test_other_endpoints.py
+++ b/ct-app/tests/test_other_endpoints.py
@@ -54,29 +54,29 @@ async def test_blacklist_rpch_nodes_exceptions():
         result = await node.blacklist_rpch_nodes("some_api_endpoint")
         assert result == ("rpch", [])
 
-        # Simulate ValueError
-        mock_get.side_effect = ValueError("ValueError")
-        node = EconomicHandler(
-            "some_url",
-            "some_api_key",
-            "some_rpch_endpoint",
-            "some_subgraph_url",
-            "some_sc_address",
-        )
-        result = await node.blacklist_rpch_nodes("some_api_endpoint")
-        assert result == ("rpch", [])
+        # # Simulate ValueError
+        # mock_get.side_effect = OSError("ValueError")
+        # node = EconomicHandler(
+        #     "some_url",
+        #     "some_api_key",
+        #     "some_rpch_endpoint",
+        #     "some_subgraph_url",
+        #     "some_sc_address",
+        # )
+        # result = await node.blacklist_rpch_nodes("some_api_endpoint")
+        # assert result == ("rpch", [])
 
-        # Simulate general exception
-        mock_get.side_effect = Exception("Exception")
-        node = EconomicHandler(
-            "some_url",
-            "some_api_key",
-            "some_rpch_endpoint",
-            "some_subgraph_url",
-            "some_sc_address",
-        )
-        result = await node.blacklist_rpch_nodes("some_api_endpoint")
-        assert result == ("rpch", [])
+        # # Simulate general exception
+        # mock_get.side_effect = Exception("Exception")
+        # node = EconomicHandler(
+        #     "some_url",
+        #     "some_api_key",
+        #     "some_rpch_endpoint",
+        #     "some_subgraph_url",
+        #     "some_sc_address",
+        # )
+        # result = await node.blacklist_rpch_nodes("some_api_endpoint")
+        # assert result == ("rpch", [])
 
 
 @pytest.mark.asyncio
@@ -147,6 +147,7 @@ async def test_get_staking_participations_exceptions():
     """
     with patch("aiohttp.ClientSession.post") as mock_post:
         # Simulate ClientError
+
         mock_post.side_effect = aiohttp.ClientError("ClientError")
         node = EconomicHandler(
             "some_url",
@@ -155,7 +156,7 @@ async def test_get_staking_participations_exceptions():
             "some_subgraph_url",
             "some_sc_address",
         )
-        result = await node.get_staking_participations(
+        result = await node.get_staking_participations(  # noqa: F841
             "some_subgraph_url", "some_staking_season_address", 100
         )
         assert result == ("subgraph_data", {})

--- a/ct-app/tools/hopr_api_helper.py
+++ b/ct-app/tools/hopr_api_helper.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Callable
 
-import httpx
+import swagger_client as swagger
 from hoprd import wrapper
+from swagger_client.rest import ApiException
 
 log = logging.getLogger(__name__)
 
@@ -13,10 +13,21 @@ class HoprdAPIHelper:
     """
 
     def __init__(self, url: str, token: str):
+        self._setup(url, token)
         self.wrapper = wrapper.HoprdAPI(api_url=url, api_token=token)
 
         self._url = url
         self._token = token
+
+    def _setup(self, url: str, token: str):
+        configuration = swagger.Configuration()
+        configuration.host = f"{url}/api/v2"
+        configuration.api_key["x-auth-token"] = token
+
+        self.node_api = swagger.NodeApi(swagger.ApiClient(configuration))
+        self.message_api = swagger.MessagesApi(swagger.ApiClient(configuration))
+        self.account_api = swagger.AccountApi(swagger.ApiClient(configuration))
+        self.channels_api = swagger.ChannelsApi(swagger.ApiClient(configuration))
 
     @property
     def url(self) -> str:
@@ -26,336 +37,170 @@ class HoprdAPIHelper:
     def token(self) -> str:
         return self._token
 
-    async def _safe_call(self, func: Callable, *args, **kwargs):
-        """
-        Wrapper around each API call to handle exceptions
-        """
-        try:
-            response = await func(*args, **kwargs)
-            response.raise_for_status()
-        except httpx.HTTPError as e:
-            log.exception(f"Error calling {func.__name__}")
-            raise e
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response
-
-    async def withdraw(self, currency, amount, address):
-        method = self.wrapper.withdraw
-        args = [currency, amount, address]
-
-        log.debug("Withdrawing")
-
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error withdrawing")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
-
-    async def balance(self, type: str = "all"):
+    async def balance(self, type: str = "native"):
         """
         Returns the balance of the node.
-        :param: type: str = "all" | "hopr" | "native"
+        :param: type: str =  "hopr" | "native"
         :return: balance: int
         """
 
-        method = self.wrapper.balance
-
-        if type not in ["all", "hopr", "native"]:
-            log.error(f"Type {type} not supported")
+        if type not in ["hopr", "native"]:
+            log.error(f"Type `{type}` not supported. Use `hopr` or `native`")
             return None
 
         log.debug("Getting balance")
 
         try:
-            response = await self._safe_call(method)
-        except httpx.HTTPError:
-            log.exception
+            # thread = self.account_api.account_get_balances(async_req=True)
+            # response = thread.get()
+            response = self.account_api.account_get_balances()
+        except ApiException:
+            log.exception("Exception when calling AccountApi->account_get_balances")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->account_get_balances")
             return None
-        else:
-            if response.status_code != 200:
-                log.error(f"Error getting balance from {self.url}")
-                return None
 
-            if type == "all":
-                return response.json()
-
-            return int(response.json()[type])
-
-    async def set_alias(self, peer_id, alias):
-        method = self.wrapper.set_alias
-        args = [peer_id, alias]
-
-        log.debug("Setting alias")
-
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error setting alias")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
-
-    async def get_alias(self, alias):
-        method = self.wrapper.get_alias
-        args = [alias]
-
-        log.debug("Getting alias")
-
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error getting alias")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
-
-    async def remove_alias(self, alias):
-        method = self.wrapper.remove_alias
-        args = [alias]
-
-        log.debug("Removing alias")
-
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error removing alias")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
-
-    async def get_settings(self):
-        method = self.wrapper.get_settings
-
-        log.debug("Getting settings")
-
-        try:
-            response = await self._safe_call(method)
-        except httpx.HTTPError:
-            log.exception("Error getting settings")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
+        return int(getattr(response, type))
 
     async def get_all_channels(self, include_closed: bool):
-        method = self.wrapper.get_all_channels
-        args = [include_closed]
-
         log.debug("Getting all channels")
 
         try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error getting all channels")
+            thread = self.channels_api.channels_get_channels(
+                including_closed=include_closed, async_req=True
+            )
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
         else:
-            return response.json()
+            return response
 
     async def get_unique_safe_peerId_links(self):
         """
         Returns a dict containing all unique source_peerId-source_address links.
         """
-        method = self.wrapper.get_channel_topology
-        args = [True]  # full_topology=True ro retrieve the full topology
 
         log.debug("Getting channel topology")
 
         try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error getting channel topology")
+            thread = self.channels_api.channels_get_channel(
+                full_topology=True, async_req=True
+            )
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling ChannelsApi->channels_get_channel")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
-        else:
-            unique_peerId_address = {}
-            all_items = response.json()[
-                "all"
-            ]  # All to retrieve all channels (incomming and outgoing)
 
-            for item in all_items:
-                try:
-                    source_peer_id = item["sourcePeerId"]
-                    source_address = item["sourceAddress"]
-                except KeyError:
-                    log.exception("Error getting sourcePeerId or sourceAddress")
-                    return None
-
-                if source_peer_id not in unique_peerId_address:
-                    unique_peerId_address[source_peer_id] = source_address
-
-            return unique_peerId_address
-
-    async def get_tickets_in_channel(self, include_closed: bool):
-        method = self.wrapper.get_tickets_in_channel
-        args = [include_closed]
-
-        log.debug("Getting tickets in channel")
-
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error getting tickets in channel")
+        if not hasattr(response, "all"):
+            log.error("Response does not contain `all`")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
 
-    async def redeem_tickets_in_channel(self, peer_id):
-        method = self.wrapper.redeem_tickets_in_channel
-        args = [peer_id]
+        address_for_peer_id = {}
 
-        log.debug(f"Redeeming tickets in channel with peer {peer_id}")
+        for item in response.all:
+            peer_id = item.get("sourcePeerId", None)
+            address = item.get("sourceAddress", None)
 
-        try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception(f"Error redeeming tickets in channel with peer {peer_id}")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            return response.json()
+            if not peer_id or not address:
+                log.error("Could not get peer_id or address from a peer")
+                continue
 
-    async def redeem_tickets(self):
-        method = self.wrapper.redeem_tickets
+            address_for_peer_id[peer_id] = address
 
-        log.debug("Redeeming tickets")
+        return address_for_peer_id
 
-        try:
-            response = await self._safe_call(method)
-        except httpx.HTTPError:
-            log.exception("Error redeeming tickets")
-            return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return None
-        else:
-            if response.status_code == 204:
-                return None
-            return response.json()
-
-    async def ping(self, peer_id, metric="latency"):
-        method = self.wrapper.ping
-        args = [peer_id]
-
+    async def ping(self, peer_id: str, metric: str = "latency"):
         log.debug(f"Pinging peer {peer_id}")
 
+        body = swagger.NodePingBody(peer_id)
+
         try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception(f"Error pinging peer {peer_id}")
+            thread = self.node_api.node_ping(body=body, async_req=True)
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling NodeApi->node_ping")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
-        else:
-            json_body = response.json()
 
-            if json_body is None:
-                log.error(f"Peer {peer_id} not reachable using {self.url}")
-                return None
+        if not hasattr(response, metric):
+            log.error(f"No `{metric}` measure from peer {peer_id}")
+            return None
 
-            if metric not in json_body:
-                log.error(f"No {metric} measure from peer {peer_id}")
-                return None
+        measure = int(getattr(response, metric))
 
-            log.info(f"Measured {json_body[metric]:3d}({metric}) from peer {peer_id}")
-            return json_body[metric]
+        log.info(f"Measured {measure:3d}({metric}) from peer {peer_id}")
+        return measure
 
-    async def peers(self, param: str = "peerId", status: str = "connected", **kwargs):
-        method = self.wrapper.peers
-
+    async def peers(self, param: str = "peer_id", status: str = "connected"):
         log.debug("Getting peers")
 
         try:
-            response = await self._safe_call(method, **kwargs)
-        except httpx.HTTPError:
-            log.exception(f"Could not get peers from {self.url}")
+            thread = self.node_api.node_get_peers(quality=1, async_req=True)
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling NodeApi->node_get_peers")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
-        else:
-            json_body = response.json()
 
-            if status not in json_body:
-                log.error(f"No {status} from {self.url}")
-                return None
+        if not hasattr(response, status):
+            log.error(f"No `{status}` from {self.url}")
+            return None
 
-            if param not in json_body[status][0]:
-                log.error(f"No {param} from {self.url}")
-                return None
+        if len(getattr(response, status)) == 0:
+            log.info(f"No peer with status `{status}`")
+            return None
 
-            return [peer[param] for peer in json_body[status]]
+        if not hasattr(getattr(response, status)[0], param):
+            log.error(f"No param `{param}` found for peers")
+            return None
+
+        return [getattr(peer, param) for peer in getattr(response, status)]
 
     async def get_address(self, address: str):
-        method = self.wrapper.get_address
-
         log.debug("Getting address")
 
         try:
-            response = await self._safe_call(method)
-        except httpx.HTTPError:
-            log.exception(f"Could not connect to {self.url}")
+            thread = self.account_api.account_get_address(async_req=True)
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling AccountApi->account_get_address")
             return None
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
             return None
-        else:
-            json_body = response.json()
 
-            if address not in json_body:
-                log.error(f"No {address} from {self.url}")
-                return None
+        if not hasattr(response, address):
+            log.error(f"No {address} returned from the API")
+            return None
 
-            return json_body.get(address, None)
+        return getattr(response, address)
 
-    async def send_message(self, destination, message, hops) -> bool:
-        method = self.wrapper.send_message
-        args = [destination, message, hops]
-
+    async def send_message(
+        self, destination: str, message: str, hops: list[str]
+    ) -> bool:
         log.debug("Sending message")
 
+        body = swagger.MessagesBody(message, destination, hops)
         try:
-            response = await self._safe_call(method, *args)
-        except httpx.HTTPError:
-            log.exception("Error sending message")
-            return False
-        except UnboundLocalError:
-            log.exception(f"Could not connect to {self.url}")
-            return False
-        else:
-            if response.status_code != 202:
-                return False
+            thread = self.message_api.messages_send_message(body=body)
+            response = thread.get()
+        except ApiException:
+            log.exception("Exception when calling MessageApi->messages_send_message")
+            return None
+        except OSError:
+            log.exception("Exception when calling ChannelsApi->channels_get_channels")
+            return None
 
-        return True
+        return response

--- a/ct-app/tools/hopr_api_helper.py
+++ b/ct-app/tools/hopr_api_helper.py
@@ -1,7 +1,6 @@
 import logging
 
 import swagger_client as swagger
-from hoprd import wrapper
 from swagger_client.rest import ApiException
 
 log = logging.getLogger(__name__)
@@ -14,7 +13,6 @@ class HoprdAPIHelper:
 
     def __init__(self, url: str, token: str):
         self._setup(url, token)
-        self.wrapper = wrapper.HoprdAPI(api_url=url, api_token=token)
 
         self._url = url
         self._token = token


### PR DESCRIPTION
This PR is on the transition from the old API structure (handwritten) to the new one (generated by Swagger). It is still not using the API for MR2.0 as it is not released yet.

Only the `HoprdApiHelper` is directly affected by the changes in the API structure. However, some minor changes were required in order to conform to new parameters, and so that the tests still pass (for instance, exception raised are different).


Resolves #220