### PR TITLE
Async long running tasks now interrupted the right way

### DIFF
--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -698,9 +698,6 @@ class EconomicHandler(HOPRNode):
         self.started = True
         self.tasks.add(asyncio.create_task(self.fake_method()))
 
-        for task in self.tasks:
-            task.add_done_callback(self.tasks.discard)
-
         await asyncio.gather(*self.tasks)
 
     @wakeupcall("Entering fake method", seconds=15)
@@ -715,6 +712,7 @@ class EconomicHandler(HOPRNode):
 
         self.started = False
         for task in self.tasks:
+            task.add_done_callback(self.tasks.discard)
             task.cancel()
 
         self.tasks = set()

--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -680,6 +680,9 @@ class EconomicHandler(HOPRNode):
         self.tasks.add(asyncio.create_task(self.host_available()))
         self.tasks.add(asyncio.create_task(self.scheduler()))
 
+        for task in self.tasks:
+            task.add_done_callback(self.tasks.discard)
+
         await asyncio.gather(*self.tasks)
 
     ################## MOCKING FOR TESTING DEPLOYMENT ##################
@@ -694,6 +697,9 @@ class EconomicHandler(HOPRNode):
 
         self.started = True
         self.tasks.add(asyncio.create_task(self.fake_method()))
+
+        for task in self.tasks:
+            task.add_done_callback(self.tasks.discard)
 
         await asyncio.gather(*self.tasks)
 
@@ -710,4 +716,5 @@ class EconomicHandler(HOPRNode):
         self.started = False
         for task in self.tasks:
             task.cancel()
+
         self.tasks = set()

--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -680,9 +680,6 @@ class EconomicHandler(HOPRNode):
         self.tasks.add(asyncio.create_task(self.host_available()))
         self.tasks.add(asyncio.create_task(self.scheduler()))
 
-        for task in self.tasks:
-            task.add_done_callback(self.tasks.discard)
-
         await asyncio.gather(*self.tasks)
 
     ################## MOCKING FOR TESTING DEPLOYMENT ##################

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -232,6 +232,9 @@ class NetWatcher(HOPRNode):
         self.tasks.add(asyncio.create_task(self.transmit_peers()))
         self.tasks.add(asyncio.create_task(self.transmit_balance()))
 
+        for task in self.tasks:
+            task.add_done_callback(self.tasks.discard)
+
         await asyncio.gather(*self.tasks)
 
     def stop(self):
@@ -243,4 +246,5 @@ class NetWatcher(HOPRNode):
         self.started = False
         for task in self.tasks:
             task.cancel()
+
         self.tasks = set()

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -232,9 +232,6 @@ class NetWatcher(HOPRNode):
         self.tasks.add(asyncio.create_task(self.transmit_peers()))
         self.tasks.add(asyncio.create_task(self.transmit_balance()))
 
-        for task in self.tasks:
-            task.add_done_callback(self.tasks.discard)
-
         await asyncio.gather(*self.tasks)
 
     def stop(self):
@@ -245,6 +242,7 @@ class NetWatcher(HOPRNode):
 
         self.started = False
         for task in self.tasks:
+            task.add_done_callback(self.tasks.discard)
             task.cancel()
 
         self.tasks = set()


### PR DESCRIPTION
This PR closes the interrogation we had on "what is the best way to interrupt a long running task". The implementation relies on this [wiki-page](https://github.com/hoprnet/ct-research/wiki/Handling-of-task-interruption), and further more on how the `asyncio` library is dealing with task interruption.