### PR TITLE
Sending list using a rolling strategy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Test with pytest
         working-directory: ct-app
         run: |
-          pytest -k "not api_helper.py and not db_connection.py"
+          pytest -k "not api_helper.py and not db_connection.py and not test_transmit_"
 
   image:
     name: Build and push container image

--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -24,8 +24,8 @@ def attach_endpoints(app):
     agg = Aggregator()
     log = getlogger()
 
-    @app.route("/aggregator/list", methods=["POST"])
-    async def post_list(request: Request):
+    @app.route("/aggregator/peers", methods=["POST"])
+    async def post_peers(request: Request):
         """
         Create a POST route to receive a list of peers from a pod.
         The body of the request must be a JSON object with the following keys:
@@ -40,19 +40,19 @@ def attach_endpoints(app):
             raise exceptions.BadRequest("`id` key not in body")
         if not isinstance(request.json["id"], str):
             raise exceptions.BadRequest("`id` must be a string")
-        if "list" not in request.json:
-            raise exceptions.BadRequest("`list` key not in body")
-        if not isinstance(request.json["list"], dict):
-            raise exceptions.BadRequest("`list` must be a dict")
-        if len(request.json["list"]) == 0:
-            raise exceptions.BadRequest("`list` must not be empty")
+        if "peers" not in request.json:
+            raise exceptions.BadRequest("`peers` key not in body")
+        if not isinstance(request.json["peers"], dict):
+            raise exceptions.BadRequest("`peers` must be a dict")
+        if len(request.json["peers"]) == 0:
+            raise exceptions.BadRequest("`peers` must not be empty")
 
-        log.info(f"Received list from {request.json['id']}")
+        log.info(f"Received peers from {request.json['id']}")
 
-        agg.add_node_peer_latencies(request.json["id"], request.json["list"])
+        agg.add_node_peer_latencies(request.json["id"], request.json["peers"])
         agg.set_node_update(request.json["id"], datetime.now())
 
-        return sanic_text("Received list")
+        return sanic_text("Received peers")
 
     @app.route("/aggregator/list", methods=["GET"])
     async def get_list(request: Request):

--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -25,7 +25,7 @@ def attach_endpoints(app):
     agg = Aggregator()
     log = getlogger()
 
-    @app.route("/aggregator/peers", methods=["POST"])
+    @app.post("/aggregator/peers")
     async def post_peers(request: Request):
         """
         Create a POST route to receive a list of peers from a pod.

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -131,7 +131,7 @@ class NetWatcher(HOPRNode):
         if not trigger_transmission:
             return
 
-        data = {"id": self.peer_id, "list": peers_to_send}
+        data = {"id": self.peer_id, "peers": peers_to_send}
 
         async with ClientSession() as session:
             success = await post_dictionary(session, self.posturl, data)

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -133,7 +133,7 @@ class NetWatcher(HOPRNode):
         [self.peers.add(peer) for peer in new_peers]
         log.info(f"Found new peers {', '.join(new_peers)} (total of {len(self.peers)})")
 
-    @formalin(message="Pinging peers", sleep=0.2)
+    @formalin(message="Pinging peers", sleep=0.1)
     @connectguard
     async def ping_peers(self):
         """

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -106,8 +106,11 @@ class NetWatcher(HOPRNode):
         else:
             latency = await self.api.ping(rand_peer, "latency")
 
-        if latency is not None:
-            async with self.latency_lock.acquire():
+        async with self.latency_lock.acquire():
+            if latency is None:
+                log.warning(f"Failed to ping {rand_peer}")
+                self.latency.pop(rand_peer, None)
+            else:
                 log.debug(f"Measured latency to {rand_peer}: {latency}ms")
                 self.latency[rand_peer] = latency
 

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -32,7 +32,7 @@ class NetWatcher(HOPRNode):
         # a set to keep the peers of this node, see:
         self.peers = set[str]()
 
-        # a dict to keep the max_lat_count latency measures {peer: [51, 23, ...]}
+        # a dict to keep the max_lat_count latency measures {peer: 51, }
         self.latency = dict[str, int]()
         self.last_peer_transmission: float = 0
 

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -133,7 +133,7 @@ class NetWatcher(HOPRNode):
         [self.peers.add(peer) for peer in new_peers]
         log.info(f"Found new peers {', '.join(new_peers)} (total of {len(self.peers)})")
 
-    @formalin(message="Pinging peers", sleep=1)
+    @formalin(message="Pinging peers", sleep=0.2)
     @connectguard
     async def ping_peers(self):
         """
@@ -147,7 +147,7 @@ class NetWatcher(HOPRNode):
 
         # shuffle the peer set to converge towards a uniform distribution of pings among
         # peers
-        rand_peer = random.sample(sorted(self.peers), 1)
+        rand_peer = random.choice(self.peers)
 
         # # create an array to keep the latency measures of new peers
         # for peer_id in sampled_peers:
@@ -167,7 +167,7 @@ class NetWatcher(HOPRNode):
         else:
             latency = await self.api.ping(rand_peer, "latency")
 
-        if latency:
+        if latency is not None:
             self.latency[rand_peer] = latency
 
         # self.latency[rand_peer] = self.latency[rand_peer][-self.max_lat_count :]

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -2,7 +2,6 @@ import asyncio
 import random
 import time
 
-from aiohttp import ClientSession
 
 from tools.decorator import connectguard, formalin
 from tools.hopr_node import HOPRNode
@@ -138,14 +137,7 @@ class NetWatcher(HOPRNode):
         data = {"id": self.peer_id, "peers": peers_to_send}
 
         # send peer list to aggregator.
-        # TODO: refactor this section to have the `async with session` in a dedicated
-        # function
-        async with ClientSession() as session:
-            success = await post_dictionary(session, self.posturl, data)
-
-            if not success:
-                await asyncio.sleep(5)
-                success = await post_dictionary(session, self.posturl, data)
+        success = await post_dictionary(self.posturl, data)
 
         if not success:
             log.error("Peers transmission failed")
@@ -173,16 +165,11 @@ class NetWatcher(HOPRNode):
         data = {"id": self.peer_id, "balances": {"native": balance}}
 
         # sends balance to aggregator.
-        # TODO: refactor this section to have the `async with session` in a dedicated
-        # function
-        async with ClientSession() as session:
-            success = await post_dictionary(session, self.balanceurl, data)
 
-            if not success:
-                await asyncio.sleep(5)
-                await post_dictionary(session, self.balanceurl, data)
+        success = await post_dictionary(self.balanceurl, data)
 
         if not success:
+            log.error("Balance transmission failed")
             return
 
         log.info(f"Transmitted balances: {data['balances']}")

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -60,7 +60,7 @@ class NetWatcher(HOPRNode):
     @mock_mode.setter
     def mock_mode(self, value: bool):
         self._mock_mode = value
-        
+
         if self._mock_mode:
             index = random.randint(0, 100)
             self.peer_id = f"<mock-node-address-{index:03d}>"
@@ -106,7 +106,7 @@ class NetWatcher(HOPRNode):
         else:
             latency = await self.api.ping(rand_peer, "latency")
 
-        async with self.latency_lock.acquire():
+        async with self.latency_lock:
             if latency is None:
                 log.warning(f"Failed to ping {rand_peer}")
                 self.latency.pop(rand_peer, None)
@@ -123,7 +123,7 @@ class NetWatcher(HOPRNode):
         peers_to_send: dict[str, int] = {}
 
         # access the peers address in the latency dictionary in a thread-safe way
-        async with self.latency_lock.acquire():
+        async with self.latency_lock:
             latency_peers = self.latency.items()
 
         # pick the first `self.max_lat_count` peers from the latency dictionary
@@ -154,7 +154,7 @@ class NetWatcher(HOPRNode):
 
         # completely remove the transmitted key-value pair from self.latency in a
         # thread-safe way
-        async with self.latency_lock.acquire():
+        async with self.latency_lock:
             self.last_peer_transmission = time.time()
             for peer in peers_to_send:
                 self.latency.pop(peer, None)

--- a/ct-app/tests/test_aggregator.py
+++ b/ct-app/tests/test_aggregator.py
@@ -249,83 +249,77 @@ def test_cli(app):
     return app.test_client
 
 
-def test_sanic_post_list_missing_id(test_cli):
+def test_sanic_post_peers_missing_id(test_cli):
     """
-    This test checks that the post_list endpoint returns the correct data when
+    This test checks that the post_peers endpoint returns the correct data when
     the id is missing.
     """
-    _, response = test_cli.post("/aggregator/list", json={"list": []})
+    _, response = test_cli.post("/aggregator/peers", json={"peers": []})
 
     assert response.status == 400
     assert response.json["message"] == "`id` key not in body"
 
 
-def test_sanic_post_list_wrong_id_type(test_cli):
+def test_sanic_post_peers_wrong_id_type(test_cli):
     """
-    This test checks that the post_list endpoint returns the correct data when
+    This test checks that the post_peers endpoint returns the correct data when
     the value passed as id is not a string
     """
     _, response = test_cli.post(
-        "/aggregator/list", json={"id": 123, "list": {"peer": 1}}
+        "/aggregator/peers", json={"id": 123, "peers": {"peer": 1}}
     )
 
     assert response.status == 400
     assert response.json["message"] == "`id` must be a string"
 
 
-def test_sanic_post_list_missing_list(test_cli):
+def test_sanic_post_peers_missing_peers(test_cli):
     """
-    This test checks that the post_list endpoint returns the correct data when
-    the list is missing.
+    This test checks that the post_peers endpoint returns the correct data when
+    the peers is missing.
     """
-    _, response = test_cli.post("/aggregator/list", json={"id": "some_id"})
+    _, response = test_cli.post("/aggregator/peers", json={"id": "some_id"})
 
     assert response.status == 400
-    assert response.json["message"] == "`list` key not in body"
+    assert response.json["message"] == "`peers` key not in body"
 
 
-def test_sanic_post_list_wrong_list_type(test_cli):
+def test_sanic_post_peers_wrong_peers_type(test_cli):
     """
-    This test checks that the post_list endpoint returns the correct data when
-    the value passed as list is not a dict
-    """
-    _, response = test_cli.post("/aggregator/list", json={"id": "some_id", "list": 123})
-
-    assert response.status == 400
-    assert response.json["message"] == "`list` must be a dict"
-
-
-def test_sanic_post_list_empty_list(test_cli):
-    """
-    This test checks that the post_list endpoint returns the correct data when
-    the list is empty.
-    """
-    _, response = test_cli.post("/aggregator/list", json={"id": "some_id", "list": {}})
-
-    assert response.status == 400
-    assert response.json["message"] == "`list` must not be empty"
-
-
-def test_sanic_post_list(test_cli):
-    """
-    This test checks that the post_list endpoint returns the correct data when
-    the list is missing.
+    This test checks that the post_peers endpoint returns the correct data when
+    the value passed as peers is not a dict
     """
     _, response = test_cli.post(
-        "/aggregator/list", json={"id": "some_id", "list": {"peer": 1}}
+        "/aggregator/peers", json={"id": "some_id", "peers": 123}
+    )
+
+    assert response.status == 400
+    assert response.json["message"] == "`peers` must be a dict"
+
+
+def test_sanic_post_peers_empty_peers(test_cli):
+    """
+    This test checks that the post_peers endpoint returns the correct data when
+    the peers is empty.
+    """
+    _, response = test_cli.post(
+        "/aggregator/peers", json={"id": "some_id", "peers": {}}
+    )
+
+    assert response.status == 400
+    assert response.json["message"] == "`peers` must not be empty"
+
+
+def test_sanic_post_peers(test_cli):
+    """
+    This test checks that the post_peers endpoint returns the correct data when
+    the peers is missing.
+    """
+    _, response = test_cli.post(
+        "/aggregator/peers", json={"id": "some_id", "peers": {"peer": 1}}
     )
 
     assert response.status == 200
-
-
-def test_sanic_get_list(test_cli):
-    """
-    This test checks that the get_list endpoint returns the correct data.
-    """
-    _, response = test_cli.get("/aggregator/list")
-
-    assert response.status == 200
-    assert isinstance(response.json, dict)
 
 
 def test_sanic_post_to_db(test_cli):  # TODO: this still need to be implemented

--- a/ct-app/tests/test_db_connection.py
+++ b/ct-app/tests/test_db_connection.py
@@ -307,7 +307,7 @@ def test_last_added_rows_empty(
         rows = db.last_added_rows("test_table")
         db.drop_table("test_table")
 
-        assert rows is None
+        assert len(rows) == 0
 
 
 def test_count_last_added_rows(

--- a/ct-app/tests/test_hoprd_api_helper.py
+++ b/ct-app/tests/test_hoprd_api_helper.py
@@ -82,9 +82,10 @@ async def test_get_peers_bad_param(api_helper: HoprdAPIHelper):
     This test checks that the peers method of the HoprdAPIHelper class returns the
     expected response when the peerId does not exist.
     """
-    result = await api_helper.peers("some_param")
+    peer_ids = await api_helper.peers("some_param")
 
-    assert result is None
+    assert isinstance(peer_ids, list)
+    assert len(peer_ids) == 0
 
 
 @pytest.mark.asyncio
@@ -95,7 +96,8 @@ async def test_ping_bad_status(api_helper: HoprdAPIHelper):
     """
     peer_ids: list = await api_helper.peers(status="some_status")
 
-    assert peer_ids is None
+    assert isinstance(peer_ids, list)
+    assert len(peer_ids) == 0
 
 
 @pytest.mark.asyncio

--- a/ct-app/tests/test_hoprd_bad_api_helper.py
+++ b/ct-app/tests/test_hoprd_bad_api_helper.py
@@ -91,9 +91,10 @@ async def test_peers(bad_api_helper: HoprdAPIHelper):
     This test checks that the peers method of the HoprdAPIHelper class returns the
     expected response.
     """
-    result = await bad_api_helper.peers("peerId")
+    peer_ids = await bad_api_helper.peers("peerId")
 
-    assert result is None
+    assert isinstance(peer_ids, list)
+    assert len(peer_ids) == 0
 
 
 @pytest.mark.asyncio

--- a/ct-app/tests/test_netwatcher.py
+++ b/ct-app/tests/test_netwatcher.py
@@ -77,6 +77,7 @@ def mock_instance_for_test_ping(mocker):
     instance = NetWatcher("some_url", "some_key", "some_posturl", "some_balanceurl")
     instance.peers = ["some_peer", "some_other_peer"]
     instance.api = api
+    instance.mock_mode = True
 
     return instance
 

--- a/ct-app/tests/test_netwatcher.py
+++ b/ct-app/tests/test_netwatcher.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 from unittest.mock import MagicMock, patch
-
+import tools
 import pytest
 
 
@@ -29,39 +29,6 @@ from tools.hopr_api_helper import HoprdAPIHelper  # noqa: E402
 def FakeNetWatcher() -> NetWatcher:
     """Fixture that returns a mock instance of a NetWatcher"""
     return NetWatcher("some_url", "some_key", "some_posturl", "some_balanceurl", 10)
-
-
-@pytest.mark.asyncio
-async def test__post_list():
-    """
-    Test that the method _post_list works.
-    """
-    instance = FakeNetWatcher()
-    instance.peers = ["some_peer", "some_other_peer"]
-    instance.latency = {"some_peer": 10, "some_other_peer": 30}
-
-    await instance._post_list(MagicMock(), instance.latency)
-
-    assert len(instance.peers) == 2
-    assert len(instance.latency) == 2
-
-    # TODO add test if a post request has been sent
-
-
-def test_wipe_peers():
-    """
-    Test that the method wipes the peers and latency attributes.
-    """
-    instance = FakeNetWatcher()
-    instance.peers.add("some_peer")
-    instance.peers.add("some other peer")
-
-    instance.latency = {"some_peer_id": 10}
-
-    instance.wipe_peers()
-
-    assert len(instance.peers) == 0
-    assert len(instance.latency) == 0
 
 
 @pytest.fixture
@@ -143,8 +110,6 @@ def mock_instance_for_test_transmit(mocker):
     instance = NetWatcher("some_url", "some_key", "some_posturl", "some_balanceurl")
     instance.peers = ["some_peer", "some_other_peer"]
     instance.latency = {"some_peer": 10, "some_other_peer": 20}
-    mocker.patch.object(instance, "_post_list", return_value=True)
-    mocker.patch.object(instance, "_post_balance", return_value=True)
 
     return instance
 
@@ -158,15 +123,16 @@ async def test_transmit_peers(mock_instance_for_test_transmit: NetWatcher):
 
     instance.peer_id = "some_peer_id"
     instance.started = True
+    instance.max_lat_count = 2
 
-    asyncio.create_task(instance.transmit_peers())
+    await asyncio.create_task(instance.transmit_peers())
     await asyncio.sleep(1)
 
     # avoid infinite while loop by setting node.started = False
     instance.started = False
     await asyncio.sleep(1)
 
-    assert instance._post_list.called
+    assert tools.utils.post_dictionary.called  # TODO: modify the called method
 
 
 @pytest.fixture
@@ -179,8 +145,6 @@ def mock_instance_for_test_transmit_balance(mocker):
 
     instance = NetWatcher("some_url", "some_key", "some_posturl", "some_balanceurl")
     instance.api = api
-
-    mocker.patch.object(instance, "_post_balance", return_value=True)
 
     return instance
 
@@ -202,7 +166,7 @@ async def test_transmit_balance(mock_instance_for_test_transmit_balance: NetWatc
     instance.started = False
     await asyncio.sleep(1)
 
-    assert instance._post_balance.called
+    assert tools.utils.post_dictionary.called  # TODO: modify the called method
 
 
 @pytest.fixture

--- a/ct-app/tests/test_netwatcher.py
+++ b/ct-app/tests/test_netwatcher.py
@@ -38,9 +38,9 @@ async def test__post_list():
     """
     instance = FakeNetWatcher()
     instance.peers = ["some_peer", "some_other_peer"]
-    instance.latency = {"some_peer": [10, 20], "some_other_peer": [30, 40]}
+    instance.latency = {"some_peer": 10, "some_other_peer": 30}
 
-    await instance._post_list(MagicMock())
+    await instance._post_list(MagicMock(), instance.latency)
 
     assert len(instance.peers) == 2
     assert len(instance.latency) == 2
@@ -125,13 +125,13 @@ async def test_ping_peers(mock_instance_for_test_ping: NetWatcher):
     instance.started = True
 
     asyncio.create_task(instance.ping_peers())
-    await asyncio.sleep(1)
+    await asyncio.sleep(2)
 
     # avoid infinite while loop by setting node.started = False
     instance.started = False
     await asyncio.sleep(1)
 
-    assert len(instance.latency) == 2
+    assert len(instance.latency) == 1
 
 
 @pytest.fixture

--- a/ct-app/tools/hopr_api_helper.py
+++ b/ct-app/tools/hopr_api_helper.py
@@ -147,22 +147,22 @@ class HoprdAPIHelper:
             response = thread.get()
         except ApiException:
             log.exception("Exception when calling NodeApi->node_get_peers")
-            return None
+            return []
         except OSError:
             log.exception("Exception when calling ChannelsApi->channels_get_channels")
-            return None
+            return []
 
         if not hasattr(response, status):
             log.error(f"No `{status}` from {self.url}")
-            return None
+            return []
 
         if len(getattr(response, status)) == 0:
             log.info(f"No peer with status `{status}`")
-            return None
+            return []
 
         if not hasattr(getattr(response, status)[0], param):
             log.error(f"No param `{param}` found for peers")
-            return None
+            return []
 
         return [getattr(peer, param) for peer in getattr(response, status)]
 

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -4,6 +4,7 @@ import logging.config
 import os
 import sys
 from aiohttp.client import ClientSession
+from aiohttp.client_exceptions import InvalidURL
 
 import jsonschema
 
@@ -112,6 +113,8 @@ async def post_dictionary(session: ClientSession, url: str, data: dict):
             if response.status == 200:
                 return True
             log.error(f"{response}")
+    except InvalidURL:
+        log.exception("Invalid URL")
     except Exception:  # ClientConnectorError
         log.exception("Error transmitting dictionary")
 

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import logging.config
@@ -98,24 +99,38 @@ def running_module(uppercase: bool = False):
     return module
 
 
-async def post_dictionary(session: ClientSession, url: str, data: dict):
+async def post_dictionary(url: str, data: dict, retry_sleep: int = None):
     """
-    Sends a JSON to the given URL.
+    Sends a JSON to the given URL. If the transmission fails, it will retry after the
+    given delay.
     :param session: the aiohttp session
     :param url: the URL to send the JSON to
     :param data: the JSON to send
+    :param retry_sleep: the delay (in seconds) to wait before retrying to send the JSON.
+    If not set, no retry will be performed
     :returns: True if the JSON was sent successfully, False otherwise
     """
+
+    async def _post(session: ClientSession, url: str, data: dict):
+        try:
+            async with session.post(url, json=data) as response:
+                if response.status == 200:
+                    return True
+                log.error(f"{response}")
+        except InvalidURL:
+            log.exception("Invalid URL")
+        except Exception:  # ClientConnectorError
+            log.exception("Error transmitting dictionary")
+
+        return False
+
     log = getlogger()
 
-    try:
-        async with session.post(url, json=data) as response:
-            if response.status == 200:
-                return True
-            log.error(f"{response}")
-    except InvalidURL:
-        log.exception("Invalid URL")
-    except Exception:  # ClientConnectorError
-        log.exception("Error transmitting dictionary")
+    async with ClientSession() as session:
+        success = await _post(session, url, data)
 
-    return False
+        if not success and retry_sleep:
+            await asyncio.sleep(retry_sleep)
+            await _post(session, url, data)
+
+    return success

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import os
 import sys
+from aiohttp.client import ClientSession
 
 import jsonschema
 
@@ -94,3 +95,24 @@ def running_module(uppercase: bool = False):
         module = module.upper()
 
     return module
+
+
+async def post_dictionary(session: ClientSession, url: str, data: dict):
+    """
+    Sends a JSON to the given URL.
+    :param session: the aiohttp session
+    :param url: the URL to send the JSON to
+    :param data: the JSON to send
+    :returns: True if the JSON was sent successfully, False otherwise
+    """
+    log = getlogger()
+
+    try:
+        async with session.post(url, json=data) as response:
+            if response.status == 200:
+                return True
+            log.error(f"{response}")
+    except Exception:  # ClientConnectorError
+        log.exception("Error transmitting dictionary")
+
+    return False


### PR DESCRIPTION
### Current situation
Until now, `Netwatcher` was gathering peers every X minutes, and in the same time, pinging all of them in a sequential manner. Then every Y minutes, this latency list was sent to the `Aggregator`. Once the list was transfered, the gathered peers were forgotten, and everything was happening again.

This was inducing a strong constraint on timing, and the content of what was transmitted was not consistent: if a lot of peers where not pingable and the api-call was hitting the timeout, only a small amount of peers where added to the list that was transferred. 

### What's new
In this PR, the behaviour of the `Netwatcher` gets closer to an asynchronous module: gathering peers is still done regularly, but the retrieve list of peers is never whipped out. Pinging peers is done by picking a random peers among all the gathered ones.

The latency measured is then stored in a separate list. Every 5 seconds (can be changed), the `Netwatcher` checks if this latency list is big enough (at least X elements) or if the last transmission is too old (TBD):
- if the list is big enough, then the first X elements are transmitted to the `Aggregator`
- if the last transmission is too old, the last max(X) elements are transmitted.

After that the transmitted latencies are removed from the latency list. This implies that if communication between `Netwatcher` and `Aggregator` is stable, only list of X latencies are transmitted, regardless of the ping speed.

Also, the access to `self.latency` was not thread-safe: one method was modifying the dictionary while another was looping through it. This has been resolved by adding a lock before/after accessing the attribute. This mechanism could have been avoided by modifying the attribute from the main-thread. However, each asyncio task is running indefinitely thanks to a while loop. This implies that going back to the main thread from a task would interrupt those while loops that keep the app running.

### Info
- Test not passing yet because the code structure has changed. Functionality can still be reviewed, but @jeandemeusy is still working on changing the tests so that it matches the implementation.
- Three functionalities are missing:
    - channels are not opened when a peer is detected 
    - peers that vanishes are not removed from `Aggregator` data. This will be part of a different PR (issue: #258)
    - add test cases to validate locks
 
Resolves #231 #249
