### PR TITLE
Metrics now prometheus compatible

### DIFF
--- a/ct-app/aggregator/aggregator.py
+++ b/ct-app/aggregator/aggregator.py
@@ -1,7 +1,7 @@
 import datetime
 import threading
 
-from prometheus_client.metrics import Gauge, Histogram
+from prometheus_client.metrics import Gauge
 
 from tools import getlogger
 
@@ -59,7 +59,7 @@ class Aggregator(metaclass=Singleton):
         self.prometheus_balance = Gauge(
             "node_balance", "Node balance", ["node_address", "token"]
         )
-        self.prometheus_latency = Histogram(
+        self.prometheus_latency = Gauge(
             "peer_latency", "Peer latency", ["node_address", "peer_id"]
         )
         self.prometheus_node_update = Gauge(
@@ -85,7 +85,7 @@ class Aggregator(metaclass=Singleton):
             log.info(f"Added latency data for node {node_id}")
 
         for peer, lat in items.items():
-            self.prometheus_latency.labels(node_id, peer).observe(lat)
+            self.prometheus_latency.labels(node_id, peer).set(lat)
 
     def get_node_peer_latencies(self) -> dict:
         """

--- a/ct-app/aggregator/aggregator.py
+++ b/ct-app/aggregator/aggregator.py
@@ -111,7 +111,6 @@ class Aggregator(metaclass=Singleton):
 
             log.info(f"Set last update timestamp for node {node_id} to {timestamp}")
 
-        print(type(timestamp))
         self.prometheus_node_update.labels(node_id).set(timestamp.timestamp())
 
     def get_node_update(self, node_id: str) -> datetime.datetime:

--- a/ct-app/aggregator/aggregator.py
+++ b/ct-app/aggregator/aggregator.py
@@ -60,10 +60,10 @@ class Aggregator(metaclass=Singleton):
             "node_balance", "Node balance", ["node_address", "token"]
         )
         self.prometheus_latency = Gauge(
-            "peer_latency", "Peer latency", ["node_address", "peer_id"]
+            "peer_latency", "Last peer latency measured", ["node_address", "peer_id"]
         )
         self.prometheus_node_update = Gauge(
-            "node_update", "Node update", ["node_address"]
+            "node_update", "Last node update received", ["node_address"]
         )
 
     def add_node_peer_latencies(self, node_id: str, items: dict):

--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from sanic import exceptions
+import prometheus_client as prometheus
+from sanic import exceptions, response
 from sanic.request import Request
 from sanic.response import html as sanic_html
 from sanic.response import json as sanic_json
@@ -24,7 +25,7 @@ def attach_endpoints(app):
     agg = Aggregator()
     log = getlogger()
 
-    @app.route("/aggregator/list", methods=["POST"])
+    @app.post("/aggregator/list")
     async def post_list(request: Request):
         """
         Create a POST route to receive a list of peers from a pod.
@@ -54,7 +55,7 @@ def attach_endpoints(app):
 
         return sanic_text("Received list")
 
-    @app.route("/aggregator/list", methods=["GET"])
+    @app.get("/aggregator/list")
     async def get_list(request: Request):
         """
         Create a GET route to retrieve the aggregated list of peers/latency.
@@ -66,7 +67,7 @@ def attach_endpoints(app):
         log.info("Returned node-peer-latency list")
         return sanic_json(agg.get_node_peer_latencies())
 
-    @app.route("/aggregator/list_ui", methods=["GET"])
+    @app.get("/aggregator/list_ui")
     async def get_list_ui(request: Request):  # pragma: no cover
         """
         Create a GET route to retrieve the aggregated list of peers/latency
@@ -129,7 +130,7 @@ def attach_endpoints(app):
 
         return "".join(text)
 
-    @app.route("/aggregator/to_db", methods=["GET"])
+    @app.get("/aggregator/to_db")
     async def post_to_db(request: Request):  # pragma: no cover
         """
         Takes the peers and metrics from the _dict and sends them to the database.
@@ -165,7 +166,7 @@ def attach_endpoints(app):
 
         return sanic_text("Sent to DB")
 
-    @app.route("/aggregator/balances", methods=["POST"])
+    @app.post("/aggregator/balances")
     async def post_balance(request: Request):
         """
         Create a POST route to receive the balance of a node.
@@ -186,8 +187,9 @@ def attach_endpoints(app):
 
         return sanic_text(f"Received balance for {request.json['id']}")
 
-    @app.route("/aggregator/metrics", methods=["GET"])
-    async def get_metrics(request: Request):
-        log.info("Metrics requested")
+    @app.get("/aggregator/metrics")
+    async def metrics(request: Request):
+        output = prometheus.exposition.generate_latest().decode("utf-8")
+        content_type = prometheus.exposition.CONTENT_TYPE_LATEST
 
-        return sanic_json(agg.get_metrics())
+        return response.text(body=output, content_type=content_type)

--- a/ct-app/aggregator/setup.py
+++ b/ct-app/aggregator/setup.py
@@ -1,5 +1,4 @@
 from sanic import Sanic
-
 from tools import getlogger
 
 from .aggregator import Aggregator

--- a/ct-app/aggregator/utils.py
+++ b/ct-app/aggregator/utils.py
@@ -1,4 +1,3 @@
-# enum class with auto numbering
 import copy
 
 import numpy as np

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -56,7 +56,10 @@ class NetWatcher(HOPRNode):
     @mock_mode.setter
     def mock_mode(self, value: bool):
         self._mock_mode = value
-        self.peer_id = "<mock-node-address>"
+
+        if value is True:
+            index = random.randint(0, 100)
+            self.peer_id = f"<mock-peer-id-{index:03d}>"
 
     def wipe_peers(self):
         """

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -59,7 +59,7 @@ class NetWatcher(HOPRNode):
 
         if value is True:
             index = random.randint(0, 100)
-            self.peer_id = f"<mock-peer-id-{index:03d}>"
+            self.peer_id = f"<mock-node-address-{index:03d}>"
 
     def wipe_peers(self):
         """

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -56,7 +56,7 @@ class NetWatcher(HOPRNode):
     @mock_mode.setter
     def mock_mode(self, value: bool):
         self._mock_mode = value
-        self.peer_id = "<mock-peer-id>"
+        self.peer_id = "<mock-node-address>"
 
     def wipe_peers(self):
         """
@@ -82,13 +82,13 @@ class NetWatcher(HOPRNode):
         latency_dict = {}
         for peer in peers_copy:
             if peer in self.latency and len(self.latency[peer]) > 0:
-                latency = self.latency[peer][-1]
-            else:
-                latency = None
-
-            latency_dict[peer] = latency
+                latency_dict[peer] = self.latency[peer][-1]
 
         data = {"id": self.peer_id, "list": latency_dict}
+
+        if len(data["list"]) == 0:
+            log.info("No peers to transmit")
+            return True
 
         try:
             async with session.post(self.posturl, json=data) as response:
@@ -143,7 +143,7 @@ class NetWatcher(HOPRNode):
                 self.peers.add(peer)
                 log.info(f"Found new peer {peer} (total of {len(self.peers)})")
 
-    @formalin(message="Pinging peers", sleep=60 * 1)
+    @formalin(message="Pinging peers", sleep=60 * 0.2)
     @connectguard
     async def ping_peers(self):
         """
@@ -180,7 +180,7 @@ class NetWatcher(HOPRNode):
             self.latency[peer_id].append(latency)
             self.latency[peer_id] = self.latency[peer_id][-self.max_lat_count :]
 
-    @formalin(message="Initiated peers transmission", sleep=60 * 10)
+    @formalin(message="Initiated peers transmission", sleep=60 * 1)
     @connectguard
     async def transmit_peers(self):
         """
@@ -192,7 +192,7 @@ class NetWatcher(HOPRNode):
             if success:
                 return
 
-            asyncio.sleep(5)
+            await asyncio.sleep(5)
             await self._post_list(session)
 
         # self.wipe_peers()

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -100,13 +100,13 @@ class NetWatcher(HOPRNode):
 
         return False
 
-    async def _post_balance(self, session: ClientSession, balance: int):
+    async def _post_balance(self, session: ClientSession, balances: dict[str:int]):
         """
         Sends the node balance (xDai) to the Aggregator.
         :param session: the aiohttp session
         :param balance: the node balance
         """
-        data = {"id": self.peer_id, "balances": {"native": balance}}
+        data = {"id": self.peer_id, "balances": balances}
         try:
             async with session.post(self.balanceurl, json=data) as response:
                 if response.status == 200:
@@ -201,14 +201,18 @@ class NetWatcher(HOPRNode):
     @connectguard
     async def transmit_balance(self):
         if self.mock_mode:
-            balance = random.randint(100, 1000)
+            native_balance = random.randint(100, 1000)
+            hopr_balance = random.randint(100, 1000)
+
+            balances = {"native": native_balance, "hopr": hopr_balance}
         else:
             balance = await self.api.balance("native")
+            balances = {"native": balance}
 
-        log.info(f"Got native balance: {balance}")
+        log.info(f"Got balances: {balances}")
 
         async with ClientSession() as session:
-            success = await self._post_balance(session, balance)
+            success = await self._post_balance(session, balances)
 
             if success:
                 return

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -11,4 +11,5 @@ sanic==23.3.0
 validators==0.20.0
 sanic_testing==23.3.0
 celery==5.2.2
+prometheus_client==0.17.1
 # sanic[test]==23.3.0

--- a/ct-app/tests/test_aggregator.py
+++ b/ct-app/tests/test_aggregator.py
@@ -1,6 +1,9 @@
-from sanic.app import Sanic
-from aggregator import Aggregator
+from datetime import datetime
+
 import pytest
+from sanic.app import Sanic
+
+from aggregator import Aggregator
 from aggregator.middlewares import attach_middlewares
 from aggregator.routes import attach_endpoints
 
@@ -44,7 +47,7 @@ def test_singleton_update():
     agg2 = Aggregator()
 
     agg1.add_node_peer_latencies("pod_id", {"peer": 1})
-    agg2.set_node_update("pod_id", "timestamp")
+    agg2.set_node_update("pod_id", datetime.now())
 
     assert agg1.get_node_peer_latencies() == agg2.get_node_peer_latencies()
 
@@ -76,27 +79,12 @@ def test_get():
 
 
 @clear_instance
-def test_clear():
-    """
-    Test that the clear method works correctly.
-    """
-    pod_id = "pod_id"
-    items = {"peer": 1}
-
-    agg.add_node_peer_latencies(pod_id, items)
-
-    agg.clear_node_peer_latencies()
-
-    assert agg._node_peer_latency == {}
-
-
-@clear_instance
 def test_set_update():
     """
     Test that the set_update method works correctly.
     """
     pod_id = "pod_id"
-    timestamp = "timestamp"
+    timestamp = datetime.now()
 
     agg.set_node_update(pod_id, timestamp)
 
@@ -124,14 +112,6 @@ def test_get_update_not_in_dict():
     pod_id = "pod_id"
 
     assert not agg.get_node_update(pod_id)
-
-
-@clear_instance
-def test_get_metric():
-    """
-    Test that the get_metric method works correctly.
-    """
-    assert isinstance(agg.get_metrics(), dict)
 
 
 @clear_instance
@@ -267,16 +247,6 @@ def test_cli(app):
     This fixture returns a test client.
     """
     return app.test_client
-
-
-def test_sanic_get_metrics(test_cli):
-    """
-    This test checks that the get metrics endpoint returns the correct data.
-    """
-    _, response = test_cli.get("/aggregator/metrics")
-
-    assert response.status == 200
-    assert isinstance(response.json, dict)
 
 
 def test_sanic_post_list_missing_id(test_cli):


### PR DESCRIPTION
### Current situation
Metrics are exposed at the `Aggregator` level through an http endpoint:`aggregator/metrics`. Those metrics are in the form of a .json file (dictionary). This is not Prometheus compatible. Prometheus requires that the metrics-endpoint returns data with a specific format.

### What's new
Instead of simply returning a .json file, the metric-endpoint now returns the gathered metrics thanks to the `prometheus-client` library. This library allows to collect any data anywhere in the code, at any moment. When the metric-endpoint is called, the library gathers all the metrics stored and returns them with the desired format. 

Thus, a bunch of methods (and their corresponding test methods) have been removed, others simply adapted.
Please have a look at the Grafana dashboards for CT-app: [app](https://grafana.ctdapp.net/d/f69f814d-f6d2-4e77-8cc2-41d2e4d20d17/app-metrics), [node](https://grafana.ctdapp.net/d/b9f927f5-cb62-464c-ba12-f2e5afc1c0d5/nodes-metrics), [db](https://grafana.ctdapp.net/d/eb408bf3-425a-4cd6-b4b7-fcc57bfd36a5/db-metric-table). These dashboards are, for now, showing some metrics that where already planed to be gathered. 

The metrics gathered are not frozen yet. Anything can be added, removed. This PR sets the stage for all the metrics that needs to be monitored.

For the moment, two mocked `Netwatcher`s are sending mocked peers informations to the `Aggregator`. In the db-dashboard, the list of nodes that are in the db is greater than 2 due to modification of the mocked nodes addresses while testing.

### Notes
Please make any metric suggestion in the form of an issue.

Resolves #215 and #234 