### PR TITLE
Remaining messages now sent from next node in the list

### DIFF
--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -75,7 +75,7 @@ async def async_send_1_hop_message(
 ) -> TaskStatus:
     """
     Celery task to send `count` 1-hop messages to a peer in an async manner. A timeout
-    mecanism is implemented to stop the task if sending a given buncn of messages takes
+    mecanism is implemented to stop the task if sending a given bunch of messages takes
     too long.
     :param peer_id: Peer ID to send messages to.
     :param count: Number of messages to send.

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from celery import Celery
 from tools import HoprdAPIHelper, envvar, getlogger
@@ -8,10 +9,16 @@ log = getlogger()
 
 
 class TaskStatus(Enum):
+    """
+    Enum to represent the status of a task. This status is also used when creating a
+    task in the outgoing queue.
+    """
+
+    DEFAULT = "DEFAULT"
     SUCCESS = "SUCCESS"
-    FAILED = "FAILED"
-    RETRYING = "RETRYING"
+    RETRIED = "RETRIED"
     SPLITTED = "SPLITTED"
+    TIMEOUT = "TIMEOUT"
 
 
 app = Celery(
@@ -21,35 +28,50 @@ app = Celery(
 )
 
 
-# the name of the task is the name of the "<task_name>.<node_address>"
-@app.task(name=f"{envvar('TASK_NAME')}.{envvar('NODE_ADDRESS')}")
-def send_1_hop_message(
-    peer: str, count: int, node_list: list[str], node_index: int
-) -> TaskStatus:
+def loop_through_nodes(node_list: list[str], node_index: int) -> tuple[str, int]:
     """
-    Celery task to send `count`1-hop messages to a peer.
-    This method is the entry point for the celery worker. As the task that is executed
-    relies on asyncio, we need to run it in a decated event loop. The only call this
-    method does is to run the async method `async_send_1_hop_message`.
-    :param peer: Peer ID to send messages to.
-    :param count: Number of messages to send.
-    :param node_list: List of nodes connected to this peer, they can serve as backups.
-    :param node_index: Index of the node in the list of nodes.
+    Get the next node address in the list of nodes. If the index is out of bounds, it
+    will be reset to 0.
+    :param node_list: List of nodes to loop through.
+    :param node_index: Index of the current node.
+    :return: Tuple containing the next node address and the next node index.
     """
-    return asyncio.run(async_send_1_hop_message(peer, count, node_list, node_index))
-
-
-def get_next_node_address(node_list: list[str], node_index: int) -> tuple[str, int]:
-    if node_index == len(node_list) - 1:
-        return None, None
-
-    node_index += 1
+    node_index = (node_index + 1) % len(node_list)
 
     return node_list[node_index], node_index
 
 
+# the name of the task is the name of the "<task_name>.<node_address>"
+@app.task(name=f"{envvar('TASK_NAME')}.{envvar('NODE_ADDRESS')}")
+def send_1_hop_message(
+    peer: str,
+    message_count: int,
+    node_list: list[str],
+    node_index: int,
+    timestamp: float = time.time(),
+) -> TaskStatus:
+    """
+    Celery task to send `message_count`1-hop messages to a peer.
+    This method is the entry point for the celery worker. As the task that is executed
+    relies on asyncio, we need to run it in a decated event loop. The only call this
+    method does is to run the async method `async_send_1_hop_message`.
+    :param peer: Peer ID to send messages to.
+    :param message_count: Number of messages to send.
+    :param node_list: List of nodes connected to this peer, they can serve as backups.
+    :param node_index: Index of the node in the list of nodes.
+    :param timestamp: Timestamp at first iteration. For timeout purposes.
+    """
+    return asyncio.run(
+        async_send_1_hop_message(peer, message_count, node_list, node_index, timestamp)
+    )
+
+
 async def async_send_1_hop_message(
-    peer_id: str, count: int, node_list: list[str], node_index: int
+    peer_id: str,
+    message_count: int,
+    node_list: list[str],
+    node_index: int,
+    timestamp: float,
 ) -> TaskStatus:
     """
     Celery task to send `count`1-hop messages to a peer in an async manner.
@@ -59,8 +81,17 @@ async def async_send_1_hop_message(
     :param node_index: Index of the node in the list of nodes.
     """
 
+    # at the first iteration, the timestamp is set to the current time. At each task
+    # transfer, the method will check if the timestamp is recent enough to consider
+    # trying to send a message
+    if time.time() - timestamp > 60 * 60 * 2:  # timestamp is older than 2 hours
+        log.error("Trying to send a message for more than 2 hours, stopping")
+        return TaskStatus.TIMEOUT
+
     api_host = envvar("API_HOST")
     api_token = envvar("API_TOKEN")
+    status = TaskStatus.DEFAULT
+    sent_messages = 0
 
     api = HoprdAPIHelper(api_host, api_token)
 
@@ -76,60 +107,43 @@ async def async_send_1_hop_message(
 
     # if the node is not reachable, the task is tranfered to the next node in the list
     if address is None:
-        log.error("Could not get connect to node. Trying with a backup node")
+        log.error("Could not get connect to node. Transfering task to the next node.")
+        status = TaskStatus.RETRIED
 
-        node_address, node_index = get_next_node_address(node_list, node_index)
+    while status == TaskStatus.DEFAULT:
+        # node is reachable, messages can be sent
+        success_sending = await api.send_message(address, "foo", [peer_id])
 
-        # if there are no more nodes in the list, the task is stopped
-        if not node_address:
-            log.info("This is the last node in the list, stopping")
-            return TaskStatus.FAILED
+        if not success_sending:
+            log.error(
+                "Could not send message. Transfering remaining ones to the next node."
+            )
+            status = TaskStatus.SPLITTED
+        else:
+            sent_messages += 1
 
-        log.info(f"Redirecting task to {node_address} (#{node_index} - {api_host})")
+        if sent_messages == message_count:
+            status = TaskStatus.SUCCESS
+
+    log.info(f"{sent_messages} messages sent to `{peer_id}` via {address} ({api_host})")
+
+    if status != TaskStatus.SUCCESS:
+        node_address, node_index = loop_through_nodes(node_list, node_index)
+        log.info(
+            f"Creating task for {node_address}: {sent_messages}/{message_count} "
+            + "messages already sent"
+        )
 
         app.send_task(
             f"{envvar('TASK_NAME')}.{node_address}",
-            args=(peer_id, count, node_list, node_index),
+            args=(
+                peer_id,
+                message_count - sent_messages,
+                node_list,
+                node_index,
+                timestamp,
+            ),
             queue=node_address,
         )
 
-        return TaskStatus.RETRYING
-
-    log.info(
-        f"Sending {count} messages to `{peer_id}` "
-        + f"via {node_list[node_index]}(#{node_index} - {api_host})"
-    )
-
-    # node is reachable, messages can be sent
-    for idx in range(count):
-        state = await api.send_message(address, "foo", [peer_id])
-
-        if not state:
-            log.error("Could not send message")
-            break
-    else:
-        log.info(
-            f"{count} messages sent to `{peer_id}` "
-            + f"via {node_list[node_index]}(#{node_index} - {api_host})"
-        )
-
-        return TaskStatus.SUCCESS
-
-    log.warning("Could not send all messages")
-
-    node_address, node_index = get_next_node_address(node_list, node_index)
-
-    if not node_address:
-        log.error(
-            f"This is the last node in the list, stopping. Only sent {idx} messages"
-        )
-        return TaskStatus.FAILED
-
-    log.info(f"Redirecting task to {node_address} (#{node_index} - {api_host})")
-    app.send_task(
-        f"{envvar('TASK_NAME')}.{node_address}",
-        args=(peer_id, count - idx, node_list, node_index),
-        queue=node_address,
-    )
-
-    return TaskStatus.SPLITTED
+    return status

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -53,7 +53,7 @@ def send_1_hop_message(
     """
     Celery task to send `message_count`1-hop messages to a peer.
     This method is the entry point for the celery worker. As the task that is executed
-    relies on asyncio, we need to run it in a decated event loop. The only call this
+    relies on asyncio, we need to run it in a dedicated event loop. The only call this
     method does is to run the async method `async_send_1_hop_message`.
     :param peer: Peer ID to send messages to.
     :param message_count: Number of messages to send.

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -74,7 +74,7 @@ async def async_send_1_hop_message(
     timestamp: float,
 ) -> TaskStatus:
     """
-    Celery task to send `count`1-hop messages to a peer in an async manner.
+    Celery task to send `count` 1-hop messages to a peer in an async manner.
     :param peer_id: Peer ID to send messages to.
     :param count: Number of messages to send.
     :param node_list: List of nodes connected to this peer, they can serve as backups.

--- a/ct-app/tools/hopr_api_helper.py
+++ b/ct-app/tools/hopr_api_helper.py
@@ -49,9 +49,8 @@ class HoprdAPIHelper:
         log.debug("Getting balance")
 
         try:
-            # thread = self.account_api.account_get_balances(async_req=True)
-            # response = thread.get()
-            response = self.account_api.account_get_balances()
+            thread = self.account_api.account_get_balances(async_req=True)
+            response = thread.get()
         except ApiException:
             log.exception("Exception when calling AccountApi->account_get_balances")
             return None
@@ -190,9 +189,9 @@ class HoprdAPIHelper:
     ) -> bool:
         log.debug("Sending message")
 
-        body = swagger.MessagesBody(message, destination, hops)
+        body = swagger.MessagesBody(message, destination, path=hops)
         try:
-            thread = self.message_api.messages_send_message(body=body)
+            thread = self.message_api.messages_send_message(body=body, async_req=True)
             response = thread.get()
         except ApiException:
             log.exception("Exception when calling MessageApi->messages_send_message")

--- a/ct-app/tools/hopr_api_helper.py
+++ b/ct-app/tools/hopr_api_helper.py
@@ -192,12 +192,12 @@ class HoprdAPIHelper:
         body = swagger.MessagesBody(message, destination, path=hops)
         try:
             thread = self.message_api.messages_send_message(body=body, async_req=True)
-            response = thread.get()
+            thread.get()
         except ApiException:
             log.exception("Exception when calling MessageApi->messages_send_message")
-            return None
+            return False
         except OSError:
             log.exception("Exception when calling ChannelsApi->channels_get_channels")
-            return None
+            return False
 
-        return response
+        return True


### PR DESCRIPTION
### Current situation
Until now, the `Postman` was trying to send a defined number of messages through a node. If the peer is available, send all the messages with this node, otherwise create a task for a different node. The problem is that even if the node is available to send the first messages, it can go down at any moment, and could not be able to send all the messages.

### What's new
This PR adds a functionality to `Postman`: when sending X messages, it always checks for successful sending.
- if the sending succeeded &rarr; it tries to send the next message
- if the sending fail &rarr; it stops sending messages, and creates a task with the remaining message to send for the next node.

**Also added**
Now instead of looping through the node list until the last node, the task is looping indefinitely through this list. This comes from the fact that, even if at some point it goes down, a node can wake up at any moment and be able to send messages again. However, this can lead into a never-ending loop, if all nodes are down at the same time. This behaviour is canceled by the implementation of a timeout (yet hardcoded, that could be moved to a parameter at some point). This timeout is set on the first execution of the task, and never modified again when the task is re-dispatch to other nodes.

Resolves #236 