### PR TITLE
EH decorator accessible by anyone

### DIFF
--- a/ct-app/economic_handler/__main__.py
+++ b/ct-app/economic_handler/__main__.py
@@ -25,7 +25,7 @@ def main():
         envvar("DB_USER")
         envvar("DB_PASSWORD")
         envvar("DB_PORT", int)
-        mock_mode = envvar("MOCK_MODE", bool)
+        mock_mode = envvar("MOCK_MODE", int)
     except KeyError:
         log.exception("Missing environment variables")
         exit(ExitCode.ERROR_MISSING_ENV_VARS)

--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -8,7 +8,7 @@ import aiohttp
 from celery import Celery
 
 from assets.parameters_schema import schema as schema_name
-from tools.decorator import connectguard, econ_handler_wakeupcall, wakeupcall
+from tools.decorator import connectguard, wakeupcall_from_file, wakeupcall
 from tools.hopr_node import HOPRNode
 from tools.db_connection.database_connection import DatabaseConnection
 from tools.utils import getlogger, read_json_file, envvar
@@ -53,7 +53,7 @@ class EconomicHandler(HOPRNode):
         print(f"{self.connected=}")
         return self.connected
 
-    @econ_handler_wakeupcall(folder="/assets", filename="parameters.json")
+    @wakeupcall_from_file(folder="/assets", filename="parameters.json")
     @connectguard
     async def scheduler(self, test_staging=True):
         """

--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -53,7 +53,7 @@ class EconomicHandler(HOPRNode):
         print(f"{self.connected=}")
         return self.connected
 
-    @econ_handler_wakeupcall()
+    @econ_handler_wakeupcall(folder="/assets", filename="parameters.json")
     @connectguard
     async def scheduler(self, test_staging=True):
         """
@@ -88,11 +88,9 @@ class EconomicHandler(HOPRNode):
 
             parameters_equations_budget = ordered_tasks[0][1:]
             database_metrics = ordered_tasks[1][1]
-            print(database_metrics)
 
             # Add random stake and a random safe address to the metrics database
             _, new_database_metrics = self.add_random_data_to_metrics(database_metrics)
-            print(new_database_metrics)
 
             # Extract Parameters
             parameters, equations, budget_param = parameters_equations_budget

--- a/ct-app/tools/db_connection/database_connection.py
+++ b/ct-app/tools/db_connection/database_connection.py
@@ -345,7 +345,7 @@ class DatabaseConnection:
 
         if len(result) == 0:
             log.warning(f"No rows fetched from `{table}` because no data was found")
-            return None
+            return []
 
         log.info(f"Last added rows ({len(result)}) fetched from `{table}`")
 

--- a/ct-app/tools/decorator.py
+++ b/ct-app/tools/decorator.py
@@ -65,7 +65,7 @@ def wakeupcall(
     return decorator
 
 
-def econ_handler_wakeupcall(
+def wakeupcall_from_file(
     message: str = None, folder: str = "", filename: str = "parameters.json"
 ):
     """


### PR DESCRIPTION
Changed the way the `econ_handler_decorator` is looking for the parameter file. Before, the file was located based on the `decorator.py` path, now it is based on the current folder where the module is executed from.

Also, the name of the decorator has been changed to not mention the `EconomicHandler`.

Resolves #205 