### PR TITLE
Added APY as part of the expected reward calculation

### DIFF
--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -55,7 +55,7 @@ class EconomicHandler(HOPRNode):
 
     @wakeupcall_from_file(folder="/assets", filename="parameters.json")
     @connectguard
-    async def scheduler(self, test_staging=True):
+    async def scheduler(self, test_staging=False):
         """
         Schedules the tasks of the EconomicHandler in two different modes
         :param: staging (bool): If True, it uses the data returned by the database
@@ -622,14 +622,23 @@ class EconomicHandler(HOPRNode):
         budget = budget_param["budget"]["value"]
         budget_split_ratio = budget_param["s"]["value"]
         dist_freq = budget_param["dist_freq"]["value"]
+        budget_period_in_sec = budget_param["budget_period"]["value"]
 
         for entry in dataset.values():
             entry["budget"] = budget
             entry["budget_split_ratio"] = budget_split_ratio
             entry["distribution_frequency"] = dist_freq
+            entry["budget_period_in_sec"] = budget_period_in_sec
 
             total_exp_reward = entry["prob"] * budget
+            apy = (
+                total_exp_reward * ((60 * 60 * 24 * 365) / budget_period_in_sec)
+            ) / entry[
+                "stake"
+            ]  # shoould be total balance instead of stake.
+            # Total balance will be introduced by PR 277
             protocol_exp_reward = total_exp_reward * budget_split_ratio
+            entry["apy"] = apy
 
             entry["total_expected_reward"] = total_exp_reward
             entry["airdrop_expected_reward"] = total_exp_reward * (


### PR DESCRIPTION
Resolves #270

This PR implements the apy calculation as part of the reward calculation function. The apy calculation is based on the `budget_period` parameter from the `parameters.json` file. The budget period is calculated in seconds. Therefore, the apy formula is as follows: 

`
apy = total_exp_reward * ((60 * 60 * 24 * 365) / budget_period_in_sec) / total_balance. 
` 

Important: `total_balance` is available once #277 gets merged. Therefore, I use `stake` for now. I will exchange this with a hotfix PR once everything is merged. 

Note that with a budget period defined a second a year has 60 * 60 * 24 * 365 seconds. This approach of calcualting the apy is robust to changes in the budget as budget changed will be reflected in the `total_expected_reward`. Furthermore, changes in the budget period will lead to immediate updates of the current apy. 