### PR TITLE
Using latest Python SDK (v3)

### DIFF
--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/hoprnet/hoprd-sdk-python.git@update-to-sdk-v3
+git+https://github.com/hoprnet/hoprd-sdk-python.git@main
 aiohttp==3.8.4
 jsonschema==4.17.3
 numpy==1.25.0


### PR DESCRIPTION
Python SDK v3 has been merged into the main branch of the python-sdk repo. This change needs to be reflected in the requirement file in this repo.