### PR TITLE
Remove all node measures when node is down

### DIFF
--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -64,8 +64,8 @@ def attach_endpoints(app):
 
             return sanic_text("Data pushed to DB")
 
-    @app.get("/aggregator/check_last_updates")
-    async def check_nodes_last_update(request: Request):
+    @app.get("/aggregator/check_timestamps")
+    async def check_nodes_timestamps(request: Request):
         """
         Create a GET route to check the last update timestamp for all pods.
         """

--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import prometheus_client as prometheus
 from sanic import exceptions, response
@@ -69,7 +69,13 @@ def attach_endpoints(app):
         """
         Create a GET route to check the last update timestamp for all pods.
         """
-        pass
+        delta = timedelta(hours=2)
+        removed_node_lat, removed_nodes_time = agg.remove_too_old_nodes(delta)
+
+        return sanic_text(
+            f"Removed {removed_node_lat} nodes from latency data "
+            + f"({removed_nodes_time} from timestamp data)"
+        )
 
     @app.post("/aggregator/balances")
     async def post_balance(request: Request):

--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import prometheus_client as prometheus
 from sanic import exceptions, response
 from sanic.request import Request
-from sanic.response import html as sanic_html
-from sanic.response import json as sanic_json
 from sanic.response import text as sanic_text
 from tools.db_connection import DatabaseConnection
 from tools.utils import getlogger
@@ -47,81 +45,6 @@ def attach_endpoints(app):
 
         return sanic_text("Received peers")
 
-    @app.get("/aggregator/list")
-    async def get_list(request: Request):
-        """
-        Create a GET route to retrieve the aggregated list of peers/latency.
-        The list is returned as a JSON object with the following keys:
-        - id: the node id
-        - list: a list of peers with their latency
-        """
-
-        log.info("Returned node-peer-latency list")
-        return sanic_json(agg.get_node_peer_latencies())
-
-    @app.get("/aggregator/list_ui")
-    async def get_list_ui(request: Request):  # pragma: no cover
-        """
-        Create a GET route to retrieve the aggregated list of peers/latency
-        and generate an HTML page to display it.
-        NO NEED TO CHECK THIS METHOD, AS IT'S PURPOSE IS ONLY FOR DEBUGGING.
-        """
-        agg_info = agg.get_node_peer_latencies()
-        count = len(agg_info)
-
-        # header
-        font = "font-family:Source Code Pro;"
-        styles = {
-            "h1": f"{font}; color: #000050",
-            "h2": f"{font}; margin-bottom: 0px; color: #0000b4",
-            "date": f"{font}; font-size: small; margin: 0px",
-            "line": f"{font}; margin-left: 20px; margin-top: 2px",
-        }
-
-        html_text = []
-        html_text.append("<body style='background-color: #ffffa0'>")
-        html_text.append(f"<h1 style='{styles['h1']}'>Aggregator content</h1>")
-        html_text.append(f"<p style='{styles['line']}'>{count} pod(s) detected</p>")
-
-        # peers detected by pods
-        for pod_id, data in agg_info.items():
-            update_time = agg.get_node_update(pod_id)
-            html_text.append(_display_pod_infos(pod_id, data, update_time, styles))
-
-        if len(agg_info) == 0:
-            html_text.append(_display_pod_infos("N/A", {}, None, styles))
-
-        action = "location.href='/aggregator/to_db';"
-        html_text.append(f"<button type='button' onclick={action}>Send to DB</button>")
-        html_text.append("</body>")
-
-        return sanic_html("".join(html_text))
-
-    def _display_pod_infos(
-        pod_id: str, data_list: dict, time: datetime, styles: dict
-    ):  # pragma: no cover
-        """
-        Generate the HTML code to display the information of a pod.
-        NO NEED TO CHECK THIS METHOD, AS IT'S PURPOSE IS ONLY FOR DEBUGGING.
-        """
-
-        def peer_lines(data_list):
-            return [f"<b>{peer}</b> ({lat}ms)" for peer, lat in data_list.items()]
-
-        # peer list
-        peer_list = ", ".join(peer_lines(data_list)) if len(data_list) != 0 else "N/A"
-
-        # last updated
-        timestamp = time.strftime("%d-%m-%Y, %H:%M:%S") if time else "N/A"
-
-        text = []
-        text.append(f"<h2 style='{styles['h2']}'>Node ID: {pod_id}</h2>")
-        text.append(f"<p style='{styles['date']}'>(Last updated: {timestamp})</p>")
-
-        text.append(f"<p style='{styles['line']}'>Peers: {peer_list}</p>")
-
-        return "".join(text)
-
     @app.get("/aggregator/to_db")
     async def post_to_db(request: Request):  # pragma: no cover
         """
@@ -140,6 +63,13 @@ def attach_endpoints(app):
             log.info(f"Inserted {len(db_entries)} rows into DB")
 
             return sanic_text("Data pushed to DB")
+
+    @app.get("/aggregator/check_last_updates")
+    async def check_nodes_last_update(request: Request):
+        """
+        Create a GET route to check the last update timestamp for all pods.
+        """
+        pass
 
     @app.post("/aggregator/balances")
     async def post_balance(request: Request):

--- a/ct-app/aggregator_trigger/__main__.py
+++ b/ct-app/aggregator_trigger/__main__.py
@@ -21,12 +21,12 @@ def stop(trigger: AggregatorTrigger, caught_signal: Signals):
 
 def main():
     try:
-        endpoint = envvar("POST_TO_DB_ENDPOINT")
+        aggregator_url = envvar("AGGREGATOR_URL")
     except ValueError:
         log.exception("Missing environment variables")
         exit()
 
-    trigger = AggregatorTrigger(endpoint)
+    trigger = AggregatorTrigger(aggregator_url)
 
     # create the event loop and register the signal handlers
     loop = asyncio.new_event_loop()

--- a/ct-app/tests/test_aggregator_trigger.py
+++ b/ct-app/tests/test_aggregator_trigger.py
@@ -8,7 +8,7 @@ def test_url_construction():
     """
     instance = AggregatorTrigger("http://gcp.host.com:5000/agg/send_list_to_db")
 
-    assert validators.url(instance.endpoint_url)
+    assert validators.url(instance.endpoint)
 
 
 # the send_list_to_db() method is not tested here, but the accessed endpoint is tested


### PR DESCRIPTION
### Current situation
Until now, when a `Netwatcher` was not able to send anything to the `Aggregator`, the `Aggregator` would store infinitely not-up-to-date informations about the network. There is a mechanism at `Netwatcher` level to remove unpingable peers from the `Aggregator`, but this rely on the hypothesis that the `Netwatcher`-`Aggregator` communication is working.
Storing old information not updated could lead into sending rewards to someone not available, thus not eligible for rewards.

### What's new
In this PR, a mechanism is added to the `Aggregator` to remove all informations about a given node, if this node has not been updated in the past 2h. This check is triggered by the `AggregatorTrigger` every 2minutes, and the last update for any node should never be older than 2h (same timedelta as the logic at the `Netwatcher` level). 

Resolves #307 