### PR TITLE
Logic to block economic model if database not filled enough

### DIFF
--- a/ct-app/economic_handler/__main__.py
+++ b/ct-app/economic_handler/__main__.py
@@ -20,6 +20,7 @@ def main():
         apikey = envvar("API_KEY")
         rcphnodes = envvar("RPCH_NODES")
         subgraphurl = envvar("SUBGRAPH_URL")
+        min_database_entries = envvar("MIN_DATABASE_ENTRIES", int)
         envvar("PGHOST")
         envvar("PGPORT", int)
         envvar("PGSSLCERT")
@@ -35,10 +36,7 @@ def main():
         exit(ExitCode.ERROR_MISSING_ENV_VARS)
 
     instance = EconomicHandler(
-        apihost,
-        apikey,
-        rcphnodes,
-        subgraphurl,
+        apihost, apikey, rcphnodes, subgraphurl, min_database_entries
     )
 
     loop = asyncio.new_event_loop()

--- a/ct-app/tests/test_economic_handler.py
+++ b/ct-app/tests/test_economic_handler.py
@@ -23,10 +23,7 @@ def mock_node_for_test_start(mocker):
     mocker.patch.object(EconomicHandler, "apply_economic_model", return_value=None)
 
     return EconomicHandler(
-        "some_url",
-        "some_api_key",
-        "some_rpch_endpoint",
-        "some_subgraph_url",
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
     )
 
 
@@ -60,10 +57,7 @@ def test_stop():
     """
     mocked_task = MagicMock()
     node = EconomicHandler(
-        "some_url",
-        "some_api_key",
-        "some_rpch_endpoint",
-        "some_subgraph_url",
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
     )
     node.tasks = {mocked_task}
 

--- a/ct-app/tests/test_other_endpoints.py
+++ b/ct-app/tests/test_other_endpoints.py
@@ -7,10 +7,7 @@ from economic_handler.economic_handler import EconomicHandler
 
 def create_node():
     return EconomicHandler(
-        "some_url",
-        "some_api_key",
-        "some_rpch_endpoint",
-        "some_subgraph_url",
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
     )
 
 


### PR DESCRIPTION
This PR adds a functionality that avoid running the economic model and doing the distribution if the number of retrieved entries in the database is too low.
The threshold has the be set by an environment variable called `MIN_DATABASE_ENTRIES`. The recommended value is 100.

Resolves #313 