### PR TITLE
Using envvar to specify parameter file name

### DIFF
--- a/ct-app/economic_handler/__main__.py
+++ b/ct-app/economic_handler/__main__.py
@@ -20,6 +20,7 @@ def main():
         apikey = envvar("API_KEY")
         rcphnodes = envvar("RPCH_NODES")
         subgraphurl = envvar("SUBGRAPH_URL")
+        envvar("PARAMETER_FILE")
         envvar("PGHOST")
         envvar("PGPORT", int)
         envvar("PGSSLCERT")

--- a/ct-app/economic_handler/economic_handler.py
+++ b/ct-app/economic_handler/economic_handler.py
@@ -2,10 +2,9 @@ import asyncio
 import aiohttp
 from copy import deepcopy
 
-
 from tools.decorator import connectguard, formalin, wakeupcall_from_file  # noqa: F401
 from tools.hopr_node import HOPRNode
-from tools.utils import getlogger
+from tools.utils import getlogger, envvar
 from tools.db_connection import DatabaseConnection, NodePeerConnection
 from prometheus_client import Gauge
 
@@ -70,7 +69,7 @@ class EconomicHandler(HOPRNode):
         return self.connected
 
     @connectguard
-    # @wakeupcall_from_file(folder="assets", filename="parameters.json")
+    # @wakeupcall_from_file(folder="assets", filename=envvar("PARAMETER_FILE"))
     @formalin("Running the economic model", sleep=60)
     async def apply_economic_model(self):
         # merge unique_safe_peerId_links with database metrics and subgraph data
@@ -137,7 +136,9 @@ class EconomicHandler(HOPRNode):
         exclude_elements(eligible_peers, local_rpch + local_ct)
 
         # computation of cover traffic probability
-        equations, parameters, budget_parameters = economic_model_from_file()
+        equations, parameters, budget_parameters = economic_model_from_file(
+            envvar("PARAMETER_FILE")
+        )
         reward_probability(eligible_peers, equations, parameters)
 
         # calculate expected rewards

--- a/ct-app/economic_handler/utils_econhandler.py
+++ b/ct-app/economic_handler/utils_econhandler.py
@@ -378,7 +378,7 @@ def replace_keys_in_mock_data(unique_nodeAddress_peerId_aggbalance_links: dict):
     return new_metrics_dict
 
 
-def economic_model_from_file(filename: str = "parameters.json"):
+def economic_model_from_file(filename: str):
     """
     Reads parameters and equations from a JSON file and validates it using a schema.
     :param: filename (str): The name of the JSON file containing the parameters


### PR DESCRIPTION
This PR adds a simple functionality that can be helpful for change the frequency distribution on the fly: instead of hardcoding the parameter file name, this one is provided trough an environment variable. This will be really helpful to continue developing and testing locally with a given set of parameters, and in the same time deploying the app with an other set of parameters.

Resolves #335 