### PR TITLE
Using `wakeupcall` instead of `wakeupcall_from_file`

### DIFF
--- a/ct-app/economic_handler/utils_econhandler.py
+++ b/ct-app/economic_handler/utils_econhandler.py
@@ -204,8 +204,6 @@ def compute_rewards(dataset: dict, budget_param: dict):
         denominator = entry["ticket_price"] * entry["winning_prob"]
         entry["jobs"] = round(entry["protocol_exp_reward_per_dist"] / denominator)
 
-        print(f"{entry}")
-
     log.info("Expected rewards and jobs calculated successfully.")
 
 
@@ -227,9 +225,6 @@ def save_dict_to_csv(
 
     lines = [column_names]
 
-    print(f"{column_names=}")
-    print(f"{lines=}")
-    print(f"{data=}")
     for key, value in data.items():
         lines.append([key] + list(value.values()))
 
@@ -410,3 +405,22 @@ def economic_model_from_file(filename: str):
 
     log.info("Fetched parameters and equations.")
     return contents["equations"], contents["parameters"], contents["budget_param"]
+
+
+def determine_delay_from_parameters(
+    folder: str = "", filename: str = "parameters.json"
+):
+    """
+    Determines the number of seconds from the JSON contents.
+    :param folder: the folder where the parameters file is located
+    :param filename: the name of the parameters file
+    :returns: (int): The number of seconds to sleep
+    """
+    parameters_file_path = os.path.join(folder, filename)
+
+    contents = read_json_on_gcp("ct-platform-ct", parameters_file_path, schema_name)
+
+    period_in_seconds = contents["budget_param"]["budget_period"]["value"]
+    distribution_count = contents["budget_param"]["dist_freq"]["value"]
+
+    return period_in_seconds / distribution_count

--- a/ct-app/tests/test_economic_handler.py
+++ b/ct-app/tests/test_economic_handler.py
@@ -1,27 +1,14 @@
 # import json
-import functools
 import os
 import pytest
 from unittest.mock import MagicMock, patch
 
 os.environ["PARAMETER_FILE"] = "parameters.json"
 
-
-def mock_decorator(*args, **kwargs):
-    """Decorate by doing nothing."""
-
-    def decorator(func):
-        @functools.wraps(func)
-        async def decorated_function(*args, **kwargs):
-            return await func(*args, **kwargs)
-
-        return decorated_function
-
-    return decorator
-
-
 # PATCH THE DECORATOR HERE
-patch("tools.decorator.wakeupcall", mock_decorator).start()
+patch(
+    "economic_handler.utils_econhandler.determine_delay_from_parameters", return_value=5
+).start()
 
 
 from economic_handler.economic_handler import EconomicHandler  # noqa: E402

--- a/ct-app/tests/test_economic_handler.py
+++ b/ct-app/tests/test_economic_handler.py
@@ -1,9 +1,28 @@
 # import json
+import functools
 import os
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 os.environ["PARAMETER_FILE"] = "parameters.json"
+
+
+def mock_decorator(*args, **kwargs):
+    """Decorate by doing nothing."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        async def decorated_function(*args, **kwargs):
+            return await func(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
+
+
+# PATCH THE DECORATOR HERE
+patch("tools.decorator.wakeupcall", mock_decorator).start()
+
 
 from economic_handler.economic_handler import EconomicHandler  # noqa: E402
 


### PR DESCRIPTION
### Current situtation
On `EconomicHandler` instance start, a distribution is automatically executed. If the pod crashes on production, it is automatically being restarted, thus triggering a distribution. This is an undesired situation.

### What's new
In this PR, the triggering of the distribution is done by the `wakeupcall` decorator instead of `wakeupcall_from_file`. The latter was not waiting for the right time to start, but way directly executing the decorating method, and then sleeps. The `wakeupcall` decorator sleep first until the right time, then execution the method, and sleeps again for the desired amount of time.

Resolves #347 