### PR TITLE
Fake task write in rewardTable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,3 @@ foo*.*
 foo*/
 run_*.sh
 .DS_Store
-
-ct-app/tools/db_connection/__main__.py

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 import time
 from enum import Enum
 
@@ -204,3 +205,16 @@ def fake_task(
     log.info(f"Fake task execution started at {timestamp}")
     log.info(f"{expected_count} messages ment to be sent to {peer}")
     log.info(f"Node list: {node_list} (starting at index {node_index})")
+
+    app.send_task(
+        "feedback_task",
+        args=(
+            peer,
+            node_list[node_index],
+            random.randint(0, expected_count),
+            expected_count,
+            TaskStatus.SUCCESS.value,
+            timestamp,
+        ),
+        queue="feedback",
+    )


### PR DESCRIPTION
This PR makes the Postman's `fake_task` more "complex". Instead of simply writing messages in the logs, it now creates a task for the feedback queue, that should then store informations in the reward table of the database