### PR TITLE
Logging simplification

### DIFF
--- a/ct-app/aggregator/routes.py
+++ b/ct-app/aggregator/routes.py
@@ -5,7 +5,7 @@ from sanic import exceptions, response
 from sanic.request import Request
 from sanic.response import text as sanic_text
 from tools.db_connection import DatabaseConnection
-from tools.utils import getlogger
+from tools import getlogger
 
 from .aggregator import Aggregator
 

--- a/ct-app/tools/__init__.py
+++ b/ct-app/tools/__init__.py
@@ -8,6 +8,7 @@ from .utils import (
     read_json_on_gcp,
     running_module,
     write_csv_on_gcp,
+    post_dictionary,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "running_module",
     "write_csv_on_gcp",
     "read_json_on_gcp",
+    "post_dictionary",
 ]

--- a/ct-app/tools/logger/coloredformatter.py
+++ b/ct-app/tools/logger/coloredformatter.py
@@ -20,11 +20,11 @@ def formatter_message(message, use_color=True):
 
 
 COLORS = {
-    "warning": YELLOW,
-    "info": WHITE,
     "debug": BLUE,
-    "critical": YELLOW,
+    "info": GREEN,
+    "warning": YELLOW,
     "error": RED,
+    "critical": RED,
 }
 
 

--- a/ct-app/tools/logger/coloredformatter.py
+++ b/ct-app/tools/logger/coloredformatter.py
@@ -20,11 +20,11 @@ def formatter_message(message, use_color=True):
 
 
 COLORS = {
-    "WARNING": YELLOW,
-    "INFO": WHITE,
-    "DEBUG": BLUE,
-    "CRITICAL": YELLOW,
-    "ERROR": RED,
+    "warning": YELLOW,
+    "info": WHITE,
+    "debug": BLUE,
+    "critical": YELLOW,
+    "error": RED,
 }
 
 
@@ -38,6 +38,7 @@ class ColoredFormatter(logging.Formatter):
         self.use_color = use_color
 
     def format(self, record):
+        record.levelname = record.levelname.lower()
         levelname = record.levelname
         if self.use_color and levelname in COLORS:
             levelname_color = (

--- a/ct-app/tools/logger/coloredlogger.py
+++ b/ct-app/tools/logger/coloredlogger.py
@@ -16,7 +16,7 @@ class ColoredLogger(logging.Logger):
     def __init__(self, name):
         logging.Logger.__init__(self, name, logging.DEBUG)
 
-        color_formatter = ColoredFormatter(self.COLOR_FORMAT, False)
+        color_formatter = ColoredFormatter(self.COLOR_FORMAT, True)
 
         console = logging.StreamHandler()
         console.setFormatter(color_formatter)

--- a/ct-app/tools/logger/coloredlogger.py
+++ b/ct-app/tools/logger/coloredlogger.py
@@ -9,7 +9,7 @@ class ColoredLogger(logging.Logger):
     A logger that allows to color the output of the logger.
     """
 
-    FORMAT = "[%(name)s] %(levelname)s-%(message)s"
+    FORMAT = "%(levelname)-8s %(message)s"
 
     COLOR_FORMAT = formatter_message(FORMAT, True)
 

--- a/ct-app/tools/logger/coloredlogger.py
+++ b/ct-app/tools/logger/coloredlogger.py
@@ -9,7 +9,7 @@ class ColoredLogger(logging.Logger):
     A logger that allows to color the output of the logger.
     """
 
-    FORMAT = "[%(asctime)s][%(name)s][%(levelname)-8s] %(message)s"
+    FORMAT = "[%(name)s] %(levelname)s-%(message)s"
 
     COLOR_FORMAT = formatter_message(FORMAT, True)
 

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -19,11 +19,6 @@ def getlogger() -> logging.Logger:
     Generate a logger instance based on folder and name.
     :returns: a tuple with the logger instance and the name of the log file
     """
-    # configure and get logger handler
-    module = running_module(uppercase=True)
-    if not module:
-        module = "main"
-
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("hoprd_sdk.rest").setLevel(logging.WARNING)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
@@ -36,7 +31,7 @@ def getlogger() -> logging.Logger:
     # checks if a logger already exists with the given module name
     logging.setLoggerClass(ColoredLogger)
 
-    logger = logging.getLogger(module)
+    logger = logging.getLogger("ct-app")
     logger.setLevel(logging.DEBUG)
 
     return logger

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -70,8 +70,6 @@ def running_module(uppercase: bool = False):
     :returns: the name of the module that is running"""
     argv = sys.argv[0]
 
-    print(sys.argv)
-
     if not argv.endswith("__main__.py"):
         return None
 

--- a/ct-app/tools/utils.py
+++ b/ct-app/tools/utils.py
@@ -34,8 +34,7 @@ def getlogger() -> logging.Logger:
     logging.getLogger("sqlalchemy.orm.path_registry").setLevel(logging.WARNING)
 
     # checks if a logger already exists with the given module name
-    if logging.getLoggerClass() != ColoredLogger:
-        logging.setLoggerClass(ColoredLogger)
+    logging.setLoggerClass(ColoredLogger)
 
     logger = logging.getLogger(module)
     logger.setLevel(logging.DEBUG)
@@ -69,6 +68,8 @@ def running_module(uppercase: bool = False):
     :param uppercase: if True, the module name will be returned in uppercase
     :returns: the name of the module that is running"""
     argv = sys.argv[0]
+
+    print(sys.argv)
 
     if not argv.endswith("__main__.py"):
         return None


### PR DESCRIPTION
This PR changes the way logs are printed:
- timestamp are not shown in the log line anymore: as Loki is retrieving the time at which a log is printed, the time information was available twice in a log line (see grafana dashboards), which could lead in some confusions due to the usage of different timezones between Loki and the application itself.
- Colors are used with the debug/info/warning/error keywords to outline more clearly what kind of content is in the log line
- The running module tag has been removed from line, as this information can be infered from the running module in Loki/Grafana
- Unnecessary characters have been removed to avoid filling a line with format.

### Old format
```log
[2023-11-06 10:23:53][RUNNING_MODULE][DEBUG/INFO/WARNING/ERROR] Dummy message in the log.
```

### New format
```log
debug/info/warning/error Dummy message in the log.
```
with the correct keyword highlighted with a dedicated color.