### PR TITLE
Reward calculation and sending splitted

### DIFF
--- a/ct-app/economic_handler/__main__.py
+++ b/ct-app/economic_handler/__main__.py
@@ -20,7 +20,7 @@ def main():
         apikey = envvar("API_KEY")
         rcphnodes = envvar("RPCH_NODES")
         subgraphurl = envvar("SUBGRAPH_URL")
-        min_database_entries = envvar("MIN_DATABASE_ENTRIES", int)
+        envvar("MIN_ELIGIBLE_PEERS", int)
         envvar("PARAMETER_FILE")
         envvar("PGHOST")
         envvar("PGPORT", int)
@@ -36,9 +36,7 @@ def main():
         log.exception("Missing environment variables")
         exit(ExitCode.ERROR_MISSING_ENV_VARS)
 
-    instance = EconomicHandler(
-        apihost, apikey, rcphnodes, subgraphurl, min_database_entries
-    )
+    instance = EconomicHandler(apihost, apikey, rcphnodes, subgraphurl)
 
     loop = asyncio.new_event_loop()
     loop.add_signal_handler(SIGINT, instance.stop)

--- a/ct-app/tests/test_economic_handler.py
+++ b/ct-app/tests/test_economic_handler.py
@@ -30,9 +30,10 @@ def mock_node_for_test_start(mocker):
     mocker.patch.object(EconomicHandler, "get_subgraph_data", return_value=None)
     mocker.patch.object(EconomicHandler, "close_incoming_channels", return_value=None)
     mocker.patch.object(EconomicHandler, "apply_economic_model", return_value=None)
+    mocker.patch.object(EconomicHandler, "reward_peers", return_value=None)
 
     return EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url"
     )
 
 
@@ -53,8 +54,9 @@ async def test_start(mock_node_for_test_start: EconomicHandler):
     assert node.get_subgraph_data.called
     # assert node.close_incoming_channels.called
     assert node.apply_economic_model.called
+    assert node.reward_peers.called
 
-    assert len(node.tasks) == 7
+    assert len(node.tasks) == 8
     assert node.started
 
     node.started = False
@@ -66,7 +68,7 @@ def test_stop():
     """
     mocked_task = MagicMock()
     node = EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url"
     )
     node.tasks = {mocked_task}
 

--- a/ct-app/tests/test_other_endpoints.py
+++ b/ct-app/tests/test_other_endpoints.py
@@ -7,7 +7,7 @@ from economic_handler.economic_handler import EconomicHandler
 
 def create_node():
     return EconomicHandler(
-        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url", 5
+        "some_url", "some_api_key", "some_rpch_endpoint", "some_subgraph_url"
     )
 
 


### PR DESCRIPTION
This PR splits the reward calculation and sending.
It allows a simpler threshold definition: before, a threshold was set on the database entries count. If there was enough data in the latest push, the economic model would have been triggered (considering all other informations sources available). But this could lead to an empty merged result dataset.
Now that the sending is splitted, the threshold is set on the number of eligible peers just before sending rewards.

The calculation of eligible peers is done every 2min, where the sending of rewards is done every ~7h (based on the economic model).

In this PR, a the environment variable `MIN_DATABASE_ENTRIES` changed to `MIN_ELIGIBLE_PEERS`.