### PR TITLE
Closing channels with low balance

### DIFF
--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -243,46 +243,67 @@ class NetWatcher(HOPRNode):
 
         log.info(f"Closed {len(incoming_channels_ids)} incoming channels")
 
-    @formalin(message="Opening channels to peers", sleep=20)
+    @formalin(message="Handling channels to peers", sleep=20)
     @connectguard
-    async def open_channels(self):
+    async def handle_channels(self):
         """
         Open channels to peers that have been successfully pinged at least once.
         """
         async with self.peers_pinged_once_lock:
             local_peers_pinged_once = deepcopy(self.peers_pinged_once)
 
-        # getting all channels to filter the outgoing ones from us, and retrieve the
-        # destination addresses of opened outgoing channels
-        channels = await self.api.all_channels(False)
+        # Getting all channels
+        all_channels = await self.api.all_channels(False)
 
-        outgoing_channels_peer_addresses = []
-        for channel in channels.all:
-            if channel.source_peer_id == self.peer_id and channel.status == "Open":
-                outgoing_channels_peer_addresses.append(channel.destination_address)
+        # Filtering outgoing channels
+        outgoing_channels = [
+            c for c in all_channels.all if c.source_peer_id == self.peer_id
+        ]
 
-        num_peers = len(local_peers_pinged_once)
+        # Filtering outgoing channel with status "Open" and "PendingToClose", and low
+        # balance channels
+        open_channels = [c for c in outgoing_channels if c.status == "Open"]
+        pending_to_close_channels = [
+            c for c in outgoing_channels if c.status == "PendingToClose"
+        ]
+        low_balance_channels = [
+            c
+            for c in open_channels
+            if int(c.balance / 1e18) <= envvar("MINIMUM_BALANCE_IN_CHANNEL", int)
+        ]
 
-        sample_indexes = random.sample(range(num_peers), min(num_peers, 5))
-        subdict_local_peers_pinged_once = {
-            list(local_peers_pinged_once.keys())[i]: list(
-                local_peers_pinged_once.values()
-            )[i]
-            for i in sample_indexes
+        # Getting the peer addresses behind the outgoing opened channels
+        peer_address_behind_open_channels = {
+            c.destination_address for c in open_channels
         }
+        local_peer_addresses = list(local_peers_pinged_once.values())
 
-        for peer_id, peer_address in subdict_local_peers_pinged_once.items():
-            if peer_address in outgoing_channels_peer_addresses:
-                log.info(
-                    f"Channel to {peer_id}({peer_address}) already opened. Skipping.."
-                )
-                continue
+        addresses_without_out_channel = (
+            local_peer_addresses - peer_address_behind_open_channels
+        )
 
-            log.info(f"Opening channel to {peer_id}({peer_address})")
-            success = await self.api.open_channel(
-                peer_address, envvar("CHANNEL_INITIAL_BALANCE")
+        #### CLOSE PENDING TO CLOSE CHANNELS ####
+        for channel in pending_to_close_channels:
+            log.info(f"Closing channel {channel.id} (was in PendingToClose state)")
+            success = await self.api.close_channel(channel.id)
+            log.info(f"Channel {channel.id} closed: {success}")
+
+        #### CLOSING LOW BALANCE CHANNELS ####
+        for channel in low_balance_channels:
+            log.info(
+                f"Closing channel {channel.id} (balance: {int(channel.balance)/1e18} < "
+                + f"{envvar('MINIMUM_BALANCE_IN_CHANNEL')})"
             )
-            log.info(f"Channel to {peer_id}({peer_address}) opened: {success}")
+            sucess = await self.api.close_channel(channel.id)
+            log.info(f"Channel {channel.id} closed: {sucess}")
+
+        #### OPEN NEW CHANNELS ####
+        for address in addresses_without_out_channel:
+            log.info(f"Opening channel to {address}")
+            success = await self.api.open_channel(
+                address, envvar("CHANNEL_INITIAL_BALANCE")
+            )
+            log.info(f"Channel to {address} opened: {success}")
 
     async def start(self):
         """
@@ -298,7 +319,7 @@ class NetWatcher(HOPRNode):
         self.tasks.add(asyncio.create_task(self.ping_peers()))
         self.tasks.add(asyncio.create_task(self.transmit_peers()))
         self.tasks.add(asyncio.create_task(self.transmit_balance()))
-        self.tasks.add(asyncio.create_task(self.open_channels()))
+        self.tasks.add(asyncio.create_task(self.handle_channels()))
         # self.tasks.add(asyncio.create_task(self.close_incoming_channels()))
 
         await asyncio.gather(*self.tasks)

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -269,7 +269,7 @@ class NetWatcher(HOPRNode):
         low_balance_channels = [
             c
             for c in open_channels
-            if int(c.balance / 1e18) <= envvar("MINIMUM_BALANCE_IN_CHANNEL", int)
+            if int(c.balance / 1e18) <= envvar("MINIMUM_BALANCE_IN_CHANNEL", float)
         ]
 
         # Getting the peer addresses behind the outgoing opened channels

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -243,7 +243,7 @@ class NetWatcher(HOPRNode):
 
         log.info(f"Closed {len(incoming_channels_ids)} incoming channels")
 
-    @formalin(message="Handling channels to peers", sleep=20)
+    @formalin(message="Handling channels to peers", sleep=2 * 60)
     @connectguard
     async def handle_channels(self):
         """

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -243,7 +243,7 @@ class NetWatcher(HOPRNode):
 
         log.info(f"Closed {len(incoming_channels_ids)} incoming channels")
 
-    @formalin(message="Handling channels to peers", sleep=2 * 60)
+    @formalin(message="Handling channels to peers", sleep=5 * 60 + 5)
     @connectguard
     async def handle_channels(self):
         """

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -276,7 +276,7 @@ class NetWatcher(HOPRNode):
         peer_address_behind_open_channels = {
             c.destination_address for c in open_channels
         }
-        local_peer_addresses = list(local_peers_pinged_once.values())
+        local_peer_addresses = set(local_peers_pinged_once.values())
 
         addresses_without_out_channel = (
             local_peer_addresses - peer_address_behind_open_channels
@@ -284,18 +284,20 @@ class NetWatcher(HOPRNode):
 
         #### CLOSE PENDING TO CLOSE CHANNELS ####
         for channel in pending_to_close_channels:
-            log.info(f"Closing channel {channel.id} (was in PendingToClose state)")
-            success = await self.api.close_channel(channel.id)
-            log.info(f"Channel {channel.id} closed: {success}")
+            log.info(
+                f"Closing channel to {channel.channel_id} (was in PendingToClose state)"
+            )
+            success = await self.api.close_channel(channel.channel_id)
+            log.info(f"Channel {channel.channel_id} closed: {success}")
 
         #### CLOSING LOW BALANCE CHANNELS ####
         for channel in low_balance_channels:
             log.info(
-                f"Closing channel {channel.id} (balance: {int(channel.balance)/1e18} < "
+                f"Closing channel {channel.channel_id} (balance: {int(channel.balance)/1e18} < "
                 + f"{envvar('MINIMUM_BALANCE_IN_CHANNEL')})"
             )
-            sucess = await self.api.close_channel(channel.id)
-            log.info(f"Channel {channel.id} closed: {sucess}")
+            sucess = await self.api.close_channel(channel.channel_id)
+            log.info(f"Channel {channel.channel_id} closed: {sucess}")
 
         #### OPEN NEW CHANNELS ####
         for address in addresses_without_out_channel:

--- a/ct-app/netwatcher/netwatcher.py
+++ b/ct-app/netwatcher/netwatcher.py
@@ -269,7 +269,7 @@ class NetWatcher(HOPRNode):
         low_balance_channels = [
             c
             for c in open_channels
-            if int(c.balance / 1e18) <= envvar("MINIMUM_BALANCE_IN_CHANNEL", float)
+            if int(c.balance) / 1e18 <= envvar("MINIMUM_BALANCE_IN_CHANNEL", float)
         ]
 
         # Getting the peer addresses behind the outgoing opened channels

--- a/ct-app/tests/test_netwatcher.py
+++ b/ct-app/tests/test_netwatcher.py
@@ -194,7 +194,7 @@ def mock_instance_for_test_start(mocker):
     mocker.patch.object(NetWatcher, "transmit_peers", return_value=None)
     mocker.patch.object(NetWatcher, "transmit_balance", return_value=None)
     mocker.patch.object(NetWatcher, "close_incoming_channels", return_value=None)
-    mocker.patch.object(NetWatcher, "open_channels", return_value=None)
+    mocker.patch.object(NetWatcher, "handle_channels", return_value=None)
 
     return NetWatcher("some_url", "some_api_key", "some_posturl", "some_balanceurl")
 
@@ -215,7 +215,7 @@ async def test_start(mock_instance_for_test_start: NetWatcher):
     assert instance.transmit_peers.called
     assert instance.transmit_balance.called
     # assert instance.close_incoming_channels.called
-    assert instance.open_channels.called
+    assert instance.handle_channels.called
 
     assert len(instance.tasks) == 6
 


### PR DESCRIPTION
This PR modifies the logic with which the NW opens channels. Before, it was only opening channels to peers that were missing a channel from a NW. Now, the NW still opens required channels, but also closes the ones in which only a few tokens remains. 