### PR TITLE
Storing issued messages in the rewardTable

### DIFF
--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -65,6 +65,7 @@ async def send_messages_in_batches(
     batch_size: int,
 ):
     effective_count = 0
+    issued_count = 0
 
     batches = create_batches(expected_count, batch_size)
     message_delivery_timeout = envvar("MESSAGE_DELIVERY_TIMEOUT", int)
@@ -74,7 +75,7 @@ async def send_messages_in_batches(
             # node is reachable, messages can be sent
             global_index = message_index + batch_index * batch_size
 
-            await api.send_message(
+            issued_count += await api.send_message(
                 address,
                 f"From CT: distribution to {peer_id} at {timestamp}-"
                 f"{global_index + 1}/{expected_count}",
@@ -87,7 +88,7 @@ async def send_messages_in_batches(
         messages = await api.messages_pop_all(0x0320)
         effective_count += len(messages)
 
-    return effective_count
+    return effective_count, issued_count
 
 
 @app.task(name="send_1_hop_message")
@@ -150,6 +151,7 @@ async def async_send_1_hop_message(
     feedback_status = TaskStatus.DEFAULT
 
     effective_count = 0
+    issued_count = 0
     already_in_inbox = 0
 
     api = HoprdAPIHelper(api_host, api_key)
@@ -171,7 +173,7 @@ async def async_send_1_hop_message(
     else:
         inbox = await api.messages_pop_all(0x0320)
         already_in_inbox = len(inbox)
-        effective_count = await send_messages_in_batches(
+        effective_count, issued_count = await send_messages_in_batches(
             api, peer_id, expected_count, address, timestamp, envvar("BATCH_SIZE", int)
         )
 
@@ -218,6 +220,7 @@ async def async_send_1_hop_message(
                 expected_count,
                 status.value,
                 timestamp,
+                issued_count,
             ),
             queue="feedback",
         )
@@ -231,6 +234,7 @@ async def async_send_1_hop_message(
                     0,
                     TaskStatus.LEFTOVERS.value,
                     timestamp,
+                    0,
                 ),
                 queue="feedback",
             )

--- a/ct-app/tests/test_postman.py
+++ b/ct-app/tests/test_postman.py
@@ -83,7 +83,7 @@ async def test_async_send_1_hop_message_hit_splitted(mocker):
     mocker.patch(
         "postman.postman_tasks.HoprdAPIHelper.get_address", return_value="foo_address"
     )
-    mocker.patch("postman.postman_tasks.HoprdAPIHelper.send_message", return_value=None)
+    mocker.patch("postman.postman_tasks.HoprdAPIHelper.send_message", return_value=True)
     mocker.patch("postman.postman_tasks.HoprdAPIHelper.messages_size", return_value=0)
     mocker.patch(
         "postman.postman_tasks.HoprdAPIHelper.messages_pop_all", return_value=[]
@@ -109,7 +109,7 @@ async def test_async_send_1_hop_message_hit_success(mocker):
     mocker.patch(
         "postman.postman_tasks.HoprdAPIHelper.get_address", return_value="foo_address"
     )
-    mocker.patch("postman.postman_tasks.HoprdAPIHelper.send_message", return_value=None)
+    mocker.patch("postman.postman_tasks.HoprdAPIHelper.send_message", return_value=True)
     mocker.patch("postman.postman_tasks.HoprdAPIHelper.messages_size", return_value=1)
     mocker.patch(
         "postman.postman_tasks.HoprdAPIHelper.messages_pop_all", return_value=["foo"]

--- a/ct-app/tools/db_connection/models.py
+++ b/ct-app/tools/db_connection/models.py
@@ -38,6 +38,7 @@ class Reward(Base):
     effective_count: Mapped[int]
     status: Mapped[str]
     timestamp: Mapped[datetime] = mapped_column(DateTime)
+    issued_count: Mapped[int]
 
     def __repr__(self) -> str:
         return (
@@ -45,6 +46,7 @@ class Reward(Base):
             + f"node_address={self.node_address!r}, "
             + f"expected_count={self.expected_count!r}, "
             + f"effective_count={self.effective_count!r}, "
+            + f"issued_count={self.issued_count!r}, "
             + f"status={self.status!r}, "
             + f"timestamp={self.timestamp})"
         )


### PR DESCRIPTION
A message is considered "issued" when the `api.send_message` call return a positive response. Among all the message we are expected to send, the majority of them are issued (can be not all), and some of the issued message are received back.


Storing this metric in the database will help understand what is failing where about reward distribution.