### PR TITLE
Script to generate an airdrop csv

### DIFF
--- a/ct-app/__airdrop__/__init__.py
+++ b/ct-app/__airdrop__/__init__.py
@@ -1,0 +1,5 @@
+from .gcpfile import GCPFile
+from .reward_entry import RewardEntry
+from .table_entry import TableEntry
+
+__all__ = ["GCPFile", "TableEntry", "RewardEntry"]

--- a/ct-app/__airdrop__/__main__.py
+++ b/ct-app/__airdrop__/__main__.py
@@ -7,8 +7,10 @@ from .reward_entry import RewardEntry
 @click.command()
 @click.option("--start", help="Start date, inclusive (YYYYMMDD-HHMMSS format")
 @click.option("--end", help="End date, exclusive (YYYYMMDD-HHMMSS format")
-def main(start: str, end: str = None):
-    files = GCPBucket("ct-platform-ct").files_in_range(start, end, "expected_rewards")
+@click.option("--bucket", default="ct-platform-ct", help="GCP bucket name")
+@click.option("--folder", default="expected_rewards", help="Folder name inside bucket")
+def main(start: str, end: str, bucket: str, folder: str):
+    files = GCPBucket(bucket).files_in_range(start, end, folder)
 
     # Get all entries from all files in the time range
     table_entries = sum([file.toTableEntry() for file in files], [])

--- a/ct-app/__airdrop__/__main__.py
+++ b/ct-app/__airdrop__/__main__.py
@@ -1,0 +1,35 @@
+import click
+
+from .gcpfile import GCPBucket
+from .reward_entry import RewardEntry
+
+
+@click.command()
+@click.option("--start", help="Start date, inclusive (YYYYMMDD-HHMMSS format")
+@click.option("--end", help="End date, exclusive (YYYYMMDD-HHMMSS format")
+def main(start: str, end: str = None):
+    files = GCPBucket("ct-platform-ct").files_in_range(start, end, "expected_rewards")
+
+    # Get all entries from all files in the time range
+    table_entries = sum([file.toTableEntry() for file in files], [])
+
+    # Get unique list of peers
+    peer_rewards = list(
+        {RewardEntry(e.source_node_address, e.safe_address) for e in table_entries}
+    )
+
+    # Sum for each address the rewards_per_dist
+    for entry in table_entries:
+        index = peer_rewards.index(RewardEntry(entry.source_node_address))
+        peer_rewards[index].reward += entry.reward_per_dist
+
+    # to csv using prints
+    print("node_address,safe_address,reward")
+    for peer in peer_rewards:
+        if not peer.in_network:
+            continue
+        print(f"{peer.node_address},{peer.safe_address},{peer.reward}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ct-app/__airdrop__/__main__.py
+++ b/ct-app/__airdrop__/__main__.py
@@ -5,8 +5,8 @@ from .reward_entry import RewardEntry
 
 
 @click.command()
-@click.option("--start", help="Start date, inclusive (YYYYMMDD-HHMMSS format")
-@click.option("--end", help="End date, exclusive (YYYYMMDD-HHMMSS format")
+@click.option("--start", help="Start date, inclusive (YYYYMMDD-HHMMSS format)")
+@click.option("--end", help="End date, exclusive (YYYYMMDD-HHMMSS format)")
 @click.option("--bucket", default="ct-platform-ct", help="GCP bucket name")
 @click.option("--folder", default="expected_rewards", help="Folder name inside bucket")
 def main(start: str, end: str, bucket: str, folder: str):

--- a/ct-app/__airdrop__/gcpfile.py
+++ b/ct-app/__airdrop__/gcpfile.py
@@ -1,0 +1,66 @@
+import csv
+import time
+
+from google.cloud import storage
+
+from .table_entry import TableEntry
+
+
+class GCPFile:
+    def __init__(self, bucketname: str, filename: str):
+        self.filename = filename
+        self.bucket = GCPBucket(bucketname)
+
+    @property
+    def blob(self):
+        return self.bucket.blob(self.filename)
+
+    def read(self):
+        header, rows = [], []
+
+        with self.blob.open("r") as f:
+            reader = csv.reader(f)
+
+            header = next(reader)
+            rows = [row for row in reader]
+
+        return header, rows
+
+    def toTableEntry(self):
+        header, rows = self.read()
+
+        return [TableEntry.fromList(header, item) for item in rows]
+
+    def __repr__(self):
+        return f"GCPFile(in: `{self.bucket.name}`, name: {self.filename})"
+
+
+class GCPBucket:
+    def __init__(self, name: str):
+        self.name = name
+        self.storage_client = storage.Client()
+
+    def get(self):
+        return self.storage_client.bucket(self.name)
+
+    def blob(self, filename: str):
+        return self.get().blob(filename)
+
+    def list_blobs(self, folder: str = ""):
+        return self.get().list_blobs(prefix=folder)
+
+
+    def files_in_range(self,start: str, end: str, folder: str = "") -> list[GCPFile]:
+        time_format = "%Y%m%d-%H%M%S"
+        start, end = time.strptime(start, time_format), time.strptime(end, time_format)
+
+        files: list[GCPFile] = []
+        for file in self.list_blobs(folder):
+            date_and_time: str = file.name.split("_")[-1].split(".")[0]
+            timestamp = time.strptime(date_and_time, "%Y%m%d%H%M%S")
+
+            if timestamp >= start and timestamp < end:
+                files.append(GCPFile(self.name, file.name))
+
+        return files
+                

--- a/ct-app/__airdrop__/reward_entry.py
+++ b/ct-app/__airdrop__/reward_entry.py
@@ -1,0 +1,31 @@
+class RewardEntry:
+    def __init__(self, node_address: str, safe_address: str = None, reward: float = 0):
+        self.node_address = node_address
+        self.safe_address = safe_address
+        self.reward = reward
+
+    @property
+    def in_network(self):
+        return self.safe_address is not None
+
+    def __repr__(self) -> str:
+        return f"RewardEntry({self.node_address}, {self.reward}, {self.safe_address})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, RewardEntry):
+            return False
+
+        return self.node_address == other.node_address
+
+    def __add__(self, other: object) -> object:
+        if not isinstance(other, RewardEntry):
+            return NotImplemented
+
+        if self.node_address != other.node_address:
+            return NotImplemented
+
+        self.reward += other.reward
+        return self
+
+    def __hash__(self) -> int:
+        return hash(self.node_address)

--- a/ct-app/__airdrop__/table_entry.py
+++ b/ct-app/__airdrop__/table_entry.py
@@ -1,0 +1,229 @@
+class TableEntry:
+    def __init__(self):
+        self._peer_id = None
+        self._source_node_address = None
+        self._channels_balance = None
+        self._node_peer_ids = None
+        self._safe_address = None
+        self._safe_balance = None
+        self._total_balance = None
+        self._safe_address_count = None
+        self._splitted_stake = None
+        self._trans_stake = None
+        self._prob = None
+        self._budget = None
+        self._budget_split_ratio = None
+        self._distribution_frequency = None
+        self._budget_period_in_sec = None
+        self._apy_pct = None
+        self._total_expected_reward = None
+        self._airdrop_expected_reward = None
+        self._protocol_exp_reward = None
+        self._protocol_exp_reward_per_dist = None
+        self._ticket_price = None
+        self._winning_prob = None
+        self._jobs = None
+
+    @property
+    def peer_id(self):
+        return self._peer_id
+
+    @peer_id.setter
+    def peer_id(self, value):
+        self._peer_id = value
+
+    @property
+    def source_node_address(self):
+        return self._source_node_address
+
+    @source_node_address.setter
+    def source_node_address(self, value):
+        self._source_node_address = value
+
+    @property
+    def channels_balance(self):
+        return float(self._channels_balance)
+
+    @channels_balance.setter
+    def channels_balance(self, value):
+        self._channels_balance = value
+
+    @property
+    def node_peer_ids(self):
+        return self._node_peer_ids
+
+    @node_peer_ids.setter
+    def node_peer_ids(self, value):
+        self._node_peer_ids = value
+
+    @property
+    def safe_address(self):
+        return self._safe_address
+
+    @safe_address.setter
+    def safe_address(self, value):
+        self._safe_address = value
+
+    @property
+    def safe_balance(self):
+        return float(self._safe_balance)
+
+    @safe_balance.setter
+    def safe_balance(self, value):
+        self._safe_balance = value
+
+    @property
+    def total_balance(self):
+        return float(self._total_balance)
+
+    @total_balance.setter
+    def total_balance(self, value):
+        self._total_balance = value
+
+    @property
+    def safe_address_count(self):
+        return float(self._safe_address_count)
+
+    @safe_address_count.setter
+    def safe_address_count(self, value):
+        self._safe_address_count = value
+
+    @property
+    def splitted_stake(self):
+        return float(self._splitted_stake)
+
+    @splitted_stake.setter
+    def splitted_stake(self, value):
+        self._splitted_stake = value
+
+    @property
+    def trans_stake(self):
+        return float(self._trans_stake)
+
+    @trans_stake.setter
+    def trans_stake(self, value):
+        self._trans_stake = value
+
+    @property
+    def prob(self):
+        return float(self._prob)
+
+    @prob.setter
+    def prob(self, value):
+        self._prob = value
+
+    @property
+    def budget(self):
+        return float(self._budget)
+
+    @budget.setter
+    def budget(self, value):
+        self._budget = value
+
+    @property
+    def budget_split_ratio(self):
+        return float(self._budget_split_ratio)
+
+    @budget_split_ratio.setter
+    def budget_split_ratio(self, value):
+        self._budget_split_ratio = value
+
+    @property
+    def distribution_frequency(self):
+        return float(self._distribution_frequency)
+
+    @distribution_frequency.setter
+    def distribution_frequency(self, value):
+        self._distribution_frequency = value
+
+    @property
+    def budget_period_in_sec(self):
+        return float(self._budget_period_in_sec)
+
+    @budget_period_in_sec.setter
+    def budget_period_in_sec(self, value):
+        self._budget_period_in_sec = value
+
+    @property
+    def apy_pct(self):
+        return float(self._apy_pct)
+
+    @apy_pct.setter
+    def apy_pct(self, value):
+        self._apy_pct = value
+
+    @property
+    def total_expected_reward(self):
+        return float(self._total_expected_reward)
+
+    @total_expected_reward.setter
+    def total_expected_reward(self, value):
+        self._total_expected_reward = value
+
+    @property
+    def airdrop_expected_reward(self):
+        return float(self._airdrop_expected_reward)
+
+    @airdrop_expected_reward.setter
+    def airdrop_expected_reward(self, value):
+        self._airdrop_expected_reward = value
+
+    @property
+    def protocol_exp_reward(self):
+        return float(self._protocol_exp_reward)
+
+    @protocol_exp_reward.setter
+    def protocol_exp_reward(self, value):
+        self._protocol_exp_reward = value
+
+    @property
+    def protocol_exp_reward_per_dist(self):
+        return float(self._protocol_exp_reward_per_dist)
+
+    @protocol_exp_reward_per_dist.setter
+    def protocol_exp_reward_per_dist(self, value):
+        self._protocol_exp_reward_per_dist = value
+
+    @property
+    def ticket_price(self):
+        return float(self._ticket_price)
+
+    @ticket_price.setter
+    def ticket_price(self, value):
+        self._ticket_price = value
+
+    @property
+    def winning_prob(self):
+        return float(self._winning_prob)
+
+    @winning_prob.setter
+    def winning_prob(self, value):
+        self._winning_prob = value
+
+    @property
+    def jobs(self):
+        return float(self._jobs)
+
+    @jobs.setter
+    def jobs(self, value):
+        self._jobs = value
+
+    @property
+    def reward_per_dist(self):
+        return self.total_expected_reward / self.distribution_frequency
+
+    @classmethod
+    def fromList(cls, headers, item):
+        entry = cls()
+
+        for header, value in zip(headers, item):
+            setattr(entry, header, value)
+
+        return entry
+
+    def __repr__(self):
+        return (
+            f"TableEntry(peer_id: {self.peer_id}, "
+            + f"address: {self.source_node_address}, "
+            + f"rewards/dist: {self.reward_per_dist})"
+        )


### PR DESCRIPTION
This PR adds a module called `__airdrop__` that is able to aggregate informations from multiple csv's stored on GCP. The result is printed in the console in a .csv format

The usage is the following
```bash
Usage: python -m __airdrop__ [OPTIONS]

Options:
  --start TEXT   Start date, inclusive (YYYYMMDD-HHMMSS
                 format)
  --end TEXT     End date, exclusive (YYYYMMDD-HHMMSS format)
  --bucket TEXT  GCP bucket name
  --folder TEXT  Folder name inside bucket
  --help         Show this message and exit.
```

If it is used with the following command: 
```bash
python -m __airdrop__ --start <start-date> --end <end-date>
```
the bucket and folder will be set to some default values, already pointing to the directory where ct is storing reward calculations.

If the result needs to be stored as a .csv file, simply redirect the output of the command to a file:
```bash
python -m __airdrop__ --start <start-date> --end <end-date> > output.csv
```
