### PR TITLE
Channel's filter conditions where off in Postman 

### DIFF
--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -47,7 +47,7 @@ async def channel_balance(
         filter(
             lambda c: c.destination_peer_id == dest_peer_id
             and c.source_peer_id == src_peer_id,
-            channels,
+            channels.all,
         )
     )
 

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -31,16 +31,25 @@ app = Celery(name=envvar("PROJECT_NAME"), broker=envvar("CELERY_BROKER_URL"))
 app.autodiscover_tasks(force=True)
 
 
-async def channel_balance(api: HoprdAPIHelper, address: str) -> float:
+async def channel_balance(
+    api: HoprdAPIHelper, src_peer_id: str, dest_peer_id: str
+) -> float:
     """
     Get the channel balance of a given address.
     :param api: API helper instance.
-    :param address: Address to get the balance from.
+    :param src_peer_id: Source channel peer id.
+    :param dest_peer_id: Destination channel peer id.
     :return: Channel balance of the address.
     """
-    channels = await api.outgoing_channels(address)
+    channels = await api.all_channels(False)
 
-    channel = list(filter(lambda c: c.peerAddress == address, channels))
+    channel = list(
+        filter(
+            lambda c: c.destination_peer_id == dest_peer_id
+            and c.source_peer_id == src_peer_id,
+            channels,
+        )
+    )
 
     if len(channel) == 0:
         return 0
@@ -193,22 +202,22 @@ async def async_send_1_hop_message(
     # try to connect to the node. If the `get_address` method fails, it means that the
     # node is not reachable
     try:
-        address = await api.get_address("hopr")
+        own_peer_id = await api.get_address("hopr")
     except Exception:
-        log.error("Could not get address from API")
-        address = None
+        log.error("Could not get peer id from API")
+        own_peer_id = None
     else:
-        log.info(f"Got address: {address}")
+        log.info(f"Got peer id: {own_peer_id}")
 
     # if the node is not reachable, the task is tranfered to the next node in the list
-    if address is None:
+    if own_peer_id is None:
         log.error("Could not connect to node. Transfering task to the next node.")
         status = TaskStatus.RETRIED
     else:
         inbox = await api.messages_pop_all(0x0320)
         already_in_inbox = len(inbox)
 
-        balance = await channel_balance(api, address)
+        balance = await channel_balance(api, own_peer_id, peer_id)
 
         possible_count = min(expected_count, balance // ticket_price)
 
@@ -225,7 +234,7 @@ async def async_send_1_hop_message(
                 api,
                 peer_id,
                 possible_count,
-                address,
+                own_peer_id,
                 timestamp,
                 envvar("BATCH_SIZE", int),
             )
@@ -237,7 +246,7 @@ async def async_send_1_hop_message(
 
     log.info(
         f"{effective_count}/{expected_count} messages sent to `{peer_id}` via "
-        + f"{address} ({api_host})"
+        + f"{own_peer_id} ({api_host})"
     )
     if already_in_inbox > 0:
         log.warning(f"{already_in_inbox} messages were already in the inbox")
@@ -269,7 +278,7 @@ async def async_send_1_hop_message(
             "feedback_task",
             args=(
                 peer_id,
-                address,
+                own_peer_id,
                 effective_count,
                 expected_count,
                 status.value,
@@ -283,7 +292,7 @@ async def async_send_1_hop_message(
                 "feedback_task",
                 args=(
                     peer_id,
-                    address,
+                    own_peer_id,
                     already_in_inbox,
                     0,
                     TaskStatus.LEFTOVERS.value,

--- a/ct-app/tests/test_postman.py
+++ b/ct-app/tests/test_postman.py
@@ -93,6 +93,7 @@ async def test_async_send_1_hop_message_hit_splitted(mocker):
     mocker.patch(
         "postman.postman_tasks.HoprdAPIHelper.messages_pop_all", return_value=[]
     )
+    mocker.patch("postman.postman_tasks.channel_balance", return_value=1)
 
     status, fb_status = await pm.async_send_1_hop_message(
         peer_id="foo_peer_id",


### PR DESCRIPTION
Hotfix for channel retrieval. The postman needs to detect the balance of the channel between itself and a node. This is done through the api, but the api call that was done before (`get channels/outgoing/`) has to issues:
- retrieving destination address was not possible
- retrieving balance was not possible

The api call is now changed to `get channels` and manual filtering is done to get the correct channel, thus channel balance.