### PR TITLE
Exclude peers running on old version

### DIFF
--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -11,7 +11,13 @@ from .node import Node
 
 def main():
     params = Parameters()(
-        "DISTRIBUTION_", "SUBGRAPH_", "GCP_", "ECONOMIC_MODEL_", "CHANNEL_", "RABBITMQ_"
+        "DISTRIBUTION_",
+        "SUBGRAPH_",
+        "GCP_",
+        "ECONOMIC_MODEL_",
+        "CHANNEL_",
+        "RABBITMQ_",
+        "PEER_",
     )
 
     instance = CTCore()

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -238,6 +238,16 @@ class CTCore(Base):
         eligibles = Utils.mergeTopologyPeersSubgraph(topology, peers, subgraph)
         self.debug(f"Merged topology and subgraph data ({len(eligibles)} entries).")
 
+        old_peer_addresses = [
+            peer.address
+            for peer in eligibles
+            if peer.version_is_old(self.params.peer.min_version)
+        ]
+        excluded = Utils.excludeElements(eligibles, old_peer_addresses)
+        self.debug(
+            f"Excluded peers running on old version (< {self.params.peer.min_version}) ({len(excluded)} entries)."
+        )
+
         Utils.allowManyNodePerSafe(eligibles)
         self.debug(f"Allowed many nodes per safe ({len(eligibles)} entries).")
 

--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -1,5 +1,4 @@
 from packaging.version import Version
-from packaging.version import parse as parse_version
 
 from .address import Address
 
@@ -7,7 +6,7 @@ from .address import Address
 class Peer:
     def __init__(self, id: str, address: str, version: str):
         self.address = Address(id, address)
-        self.version = parse_version(version)
+        self.version = version
         self.channel_balance = None
 
         self.safe_address = None
@@ -20,9 +19,20 @@ class Peer:
 
     def version_is_old(self, min_version: str or Version) -> bool:
         if isinstance(min_version, str):
-            min_version = parse_version(min_version)
+            min_version = Version(min_version)
 
         return self.version < min_version
+
+    @property
+    def version(self) -> Version:
+        return self._version
+
+    @version.setter
+    def version(self, value: str or Version):
+        if isinstance(value, str):
+            value = Version(value)
+
+        self._version = value
 
     @property
     def node_address(self) -> str:

--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -1,9 +1,13 @@
+from packaging.version import Version
+from packaging.version import parse as parse_version
+
 from .address import Address
 
 
 class Peer:
-    def __init__(self, id: str, address: str):
+    def __init__(self, id: str, address: str, version: str):
         self.address = Address(id, address)
+        self.version = parse_version(version)
         self.channel_balance = None
 
         self.safe_address = None
@@ -13,6 +17,12 @@ class Peer:
 
         self.economic_model = None
         self.reward_probability = None
+
+    def version_is_old(self, min_version: str or Version) -> bool:
+        if isinstance(min_version, str):
+            min_version = parse_version(min_version)
+
+        return self.version < min_version
 
     @property
     def node_address(self) -> str:

--- a/ct-app/core/model/topology_entry.py
+++ b/ct-app/core/model/topology_entry.py
@@ -19,6 +19,6 @@ class TopologyEntry:
         )
 
     def to_peer(self) -> Peer:
-        peer = Peer(self.peer_id, self.node_address)
+        peer = Peer(self.peer_id, self.node_address, "v0.0.0")
         peer.channel_balance = self.channels_balance
         return peer

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -84,7 +84,7 @@ class Node(Base):
 
     @property
     def print_prefix(self):
-        return '.'.join(self.url.split("//")[-1].split(".")[:2])
+        return ".".join(self.url.split("//")[-1].split(".")[:2])
 
     async def _retrieve_address(self):
         address = await self.api.get_address("all")
@@ -272,8 +272,13 @@ class Node(Base):
         Retrieve real peers from the network.
         """
 
-        results = await self.api.peers(params=["peer_id", "peer_address"], quality=0.5)
-        peers = {Peer(item["peer_id"], item["peer_address"]) for item in results}
+        results = await self.api.peers(
+            params=["peer_id", "peer_address", "reported_version"], quality=0.5
+        )
+        peers = {
+            Peer(item["peer_id"], item["peer_address"], item["reported_version"])
+            for item in results
+        }
 
         addresses_w_timestamp = {p.address.address: datetime.now() for p in peers}
 

--- a/ct-app/test/components/test_utils.py
+++ b/ct-app/test/components/test_utils.py
@@ -2,7 +2,6 @@ import datetime
 import os
 
 import pytest
-
 from core.components.utils import Utils
 from core.model.address import Address
 from core.model.peer import Peer
@@ -64,10 +63,10 @@ def test_mergeTopologyPeersSubgraph():
 
 
 def test_allowManyNodePerSafe():
-    peer_1 = Peer("id_1", "address_1")
-    peer_2 = Peer("id_2", "address_2")
-    peer_3 = Peer("id_3", "address_3")
-    peer_4 = Peer("id_5", "address_4")
+    peer_1 = Peer("id_1", "address_1", "v1.0.0")
+    peer_2 = Peer("id_2", "address_2", "v1.1.0")
+    peer_3 = Peer("id_3", "address_3", "v1.0.2")
+    peer_4 = Peer("id_4", "address_4", "v1.0.0")
 
     peer_1.safe_address = "safe_address_1"
     peer_2.safe_address = "safe_address_2"
@@ -87,11 +86,11 @@ def test_allowManyNodePerSafe():
 
 def test_excludeElements():
     source_data = [
-        Peer("id_1", "address_1"),
-        Peer("id_2", "address_2"),
-        Peer("id_3", "address_3"),
-        Peer("id_4", "address_4"),
-        Peer("id_5", "address_5"),
+        Peer("id_1", "address_1", "v1.0.0"),
+        Peer("id_2", "address_2", "v1.1.0"),
+        Peer("id_3", "address_3", "v1.0.2"),
+        Peer("id_4", "address_4", "v1.0.0"),
+        Peer("id_5", "address_5", "v1.1.1"),
     ]
     blacklist = [Address("id_2", "address_2"), Address("id_4", "address_4")]
 
@@ -147,8 +146,10 @@ def test_nextDelayInSeconds():
 def test_aggregatePeerBalanceInChannels():
     pytest.skip("Not implemented")
 
+
 def test_taskSendMessage():
     pytest.skip("Not implemented")
+
 
 def test_taskStoreFeedback():
     pytest.skip("Not implemented")

--- a/ct-app/test/model/test_peer.py
+++ b/ct-app/test/model/test_peer.py
@@ -1,0 +1,20 @@
+from core.model.peer import Peer
+
+
+def test_peer_version():
+    peer = Peer("some_id", "some_address", None)
+
+    peer.version = "v0.1.0-rc.1"
+    assert peer.version_is_old("v0.1.0-rc.2")
+
+    peer.version = "v0.1.0-rc.1"
+    assert not peer.version_is_old("v0.1.0-rc.0")
+
+    peer.version = "v0.1.1"
+    assert not peer.version_is_old("v0.1.0-rc.3")
+
+    peer.version = "v0.1.0-rc.1"
+    assert not peer.version_is_old("v0.1.0-rc.1")
+
+    peer.version = "v2.0"
+    assert not peer.version_is_old("v2.0")

--- a/ct-app/test/model/test_peer.py
+++ b/ct-app/test/model/test_peer.py
@@ -1,20 +1,26 @@
 from core.model.peer import Peer
+from packaging.version import Version
 
 
 def test_peer_version():
-    peer = Peer("some_id", "some_address", None)
+    peer = Peer("some_id", "some_address", "0.0.1")
 
     peer.version = "v0.1.0-rc.1"
     assert peer.version_is_old("v0.1.0-rc.2")
+    assert peer.version_is_old(Version("v0.1.0-rc.2"))
 
     peer.version = "v0.1.0-rc.1"
     assert not peer.version_is_old("v0.1.0-rc.0")
+    assert not peer.version_is_old(Version("v0.1.0-rc.0"))
 
     peer.version = "v0.1.1"
     assert not peer.version_is_old("v0.1.0-rc.3")
+    assert not peer.version_is_old(Version("v0.1.0-rc.3"))
 
     peer.version = "v0.1.0-rc.1"
     assert not peer.version_is_old("v0.1.0-rc.1")
+    assert not peer.version_is_old(Version("v0.1.0-rc.1"))
 
     peer.version = "v2.0"
     assert not peer.version_is_old("v2.0")
+    assert not peer.version_is_old(Version("v2.0"))

--- a/ct-app/test/model/test_peer.py
+++ b/ct-app/test/model/test_peer.py
@@ -24,3 +24,7 @@ def test_peer_version():
     peer.version = "v2.0"
     assert not peer.version_is_old("v2.0")
     assert not peer.version_is_old(Version("v2.0"))
+
+    peer.version = "v2.0"
+    assert peer.version_is_old("v2.1")
+    assert peer.version_is_old(Version("v2.1"))


### PR DESCRIPTION
To incentivize peers to update their nodes to a recent version, CT will distribute rewards only to peers running on a given version or higher. 

The minimum version is to be set by an environment variable as a string in this way: 
`export PEER_MIN_VERSION="2.0.0-rc.1"`

Any peer running on the same or a more recent rc or release than the minimum version will receive CT.