### PR TITLE
Runtime check that env variables are set before using them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ logs/
 htmlcov/
 foo*.*
 foo*/
-scripts/
-# run_*.sh
+run_*.sh
+
 .DS_Store
 */test_endurance_rules.yaml

--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -42,7 +42,9 @@ def main():
 
 if __name__ == "__main__":
     result = subprocess.run(
-        "sh ./get_params.sh ./core/".split(), capture_output=True, text=True
+        "sh ./scripts/list_required_parameters.sh ./core/".split(),
+        capture_output=True,
+        text=True,
     ).stdout
 
     all_set_flag = True

--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -1,4 +1,5 @@
 import asyncio
+import subprocess
 from signal import SIGINT, SIGTERM
 
 from prometheus_client import start_http_server
@@ -40,4 +41,19 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    result = subprocess.run(
+        "sh ./get_params.sh ./core/".split(), capture_output=True, text=True
+    ).stdout
+
+    all_set_flag = True
+    for var in result.splitlines():
+        exists = Utils.envvarExists(var)
+        all_set_flag *= exists
+
+        # print var with a leading check mark if it exists or red X (emoji) if it doesn't
+        print(f"{'✅' if exists else '❌'} {var}")
+
+    if all_set_flag:
+        main()
+    else:
+        print("Some required environment variables are missing !")

--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -1,5 +1,4 @@
 import asyncio
-import subprocess
 from signal import SIGINT, SIGTERM
 
 from prometheus_client import start_http_server
@@ -46,23 +45,5 @@ def main():
 
 
 if __name__ == "__main__":
-    result = subprocess.run(
-        "sh ./scripts/list_required_parameters.sh ./core/".split(),
-        capture_output=True,
-        text=True,
-    ).stdout
-
-    all_set_flag = True
-    for var in result.splitlines():
-        exists = Utils.envvarExists(var)
-        all_set_flag *= exists
-
-        # print var with a leading check mark if it exists or red X (emoji) if it doesn't
-        print(f"{'✅' if exists else '❌'} {var}")
-
-    if all_set_flag:
+    if Utils.checkRequiredEnvVar("core"):
         main()
-    else:
-        print("Some required environment variables are missing !")
-
-# TODO Replace prints by logs

--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -5,7 +5,7 @@ from prometheus_client import start_http_server
 
 from .components.parameters import Parameters
 from .components.utils import Utils
-from .core import CTCore
+from .core import Core
 from .node import Node
 
 
@@ -14,7 +14,7 @@ def main():
         "DISTRIBUTION_", "SUBGRAPH_", "GCP_", "ECONOMIC_MODEL_", "CHANNEL_", "RABBITMQ_"
     )
 
-    instance = CTCore()
+    instance = Core()
     instance.nodes = Node.fromAddressListAndKey(
         *Utils.nodesAddresses("NODE_ADDRESS_", "NODE_KEY")
     )

--- a/ct-app/core/__main__.py
+++ b/ct-app/core/__main__.py
@@ -14,12 +14,12 @@ def main():
     params = Parameters()(
         "DISTRIBUTION_", "SUBGRAPH_", "GCP_", "ECONOMIC_MODEL_", "CHANNEL_", "RABBITMQ_"
     )
-    
+
     test_lines = [["header"], ["value"]]
     filename = Utils.generateFilename("", "startup", "csv")
     Utils.stringArrayToGCP(params.gcp.bucket, filename, test_lines)
 
-    instance = CTCore()
+    instance = Core()
 
     instance.nodes = Node.fromAddressListAndKey(
         *Utils.nodesAddresses("NODE_ADDRESS_", "NODE_KEY")
@@ -64,3 +64,5 @@ if __name__ == "__main__":
         main()
     else:
         print("Some required environment variables are missing !")
+
+# TODO Replace prints by logs

--- a/ct-app/core/components/baseclass.py
+++ b/ct-app/core/components/baseclass.py
@@ -20,6 +20,10 @@ class Base:
     def print_prefix(self) -> str:
         return ""
 
+    @classmethod
+    def class_prefix(cls) -> str:
+        return f"{cls.__name__.upper()}_"
+
     def __format(self, message: str, color: str = "\033[0m"):
         return f"{color}{self.print_prefix}\033[0m | {message}"
 

--- a/ct-app/core/components/decorators.py
+++ b/ct-app/core/components/decorators.py
@@ -48,7 +48,7 @@ def formalin(message: Optional[str] = None):
     def decorator(func):
         @functools.wraps(func)
         async def wrapper(self, *args, **kwargs):
-            _delay = Flags.getEnvironmentFlagValue(func.__name__, self.flag_prefix)
+            _delay = Flags.getEnvironmentFlagValue(func.__name__, self.class_prefix())
 
             if _delay != 0:
                 self.debug(f"Running `{func.__name__}` every {_delay} seconds")

--- a/ct-app/core/components/decorators.py
+++ b/ct-app/core/components/decorators.py
@@ -28,7 +28,7 @@ def flagguard(func):
 
     @functools.wraps(func)
     async def wrapper(self, *args, **kwargs):
-        flags = Flags.getEnvironmentFlags(self.flag_prefix)
+        flags = Flags.getEnvironmentFlags(self.class_prefix())
 
         if func.__name__ not in flags:
             self.error(f"Feature `{func.__name__}` not yet available")

--- a/ct-app/core/components/flags.py
+++ b/ct-app/core/components/flags.py
@@ -24,6 +24,6 @@ class Flags:
             cls._cache_flags = [
                 key for key in environ.keys() if key.startswith(cls.global_prefix)
             ]
-        
+
         _prefix = cls.global_prefix + prefix
         return [item.replace(_prefix, "").lower() for item in cls._cache_flags]

--- a/ct-app/core/components/parameters.py
+++ b/ct-app/core/components/parameters.py
@@ -1,9 +1,22 @@
+from typing import Any
+
+from .baseclass import Base
 from .utils import Utils
 
 
-class Parameters:
+class Parameters(Base):
+    table = []
+
     def __init__(self):
-        pass
+        super().__init__()
+
+    def __getattribute__(self, __name: str) -> Any:
+        # self.warning(__name)
+        self.warning(__name)
+        return object.__getattribute__(self, __name)
+
+    def __getattr__(self, item):
+        print("__getattr__ " + item)
 
     def __call__(self, *prefixes: str or list[str]):
         for prefix in prefixes:

--- a/ct-app/core/components/parameters.py
+++ b/ct-app/core/components/parameters.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from .baseclass import Base
 from .utils import Utils
 
@@ -10,17 +8,9 @@ class Parameters(Base):
     def __init__(self):
         super().__init__()
 
-    def __getattribute__(self, __name: str) -> Any:
-        # self.warning(__name)
-        self.warning(__name)
-        return object.__getattribute__(self, __name)
-
-    def __getattr__(self, item):
-        print("__getattr__ " + item)
-
     def __call__(self, *prefixes: str or list[str]):
         for prefix in prefixes:
-            subparams = self.__class__()
+            subparams = type(self)()
 
             subparams_name = prefix.lower()
             if subparams_name[-1] == "_":

--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+import subprocess
 import time
 from datetime import datetime, timedelta
 from os import environ
@@ -16,8 +17,10 @@ from core.model.peer import Peer
 from core.model.subgraph_entry import SubgraphEntry
 from core.model.topology_entry import TopologyEntry
 
+from .baseclass import Base
 
-class Utils:
+
+class Utils(Base):
     @classmethod
     def envvar(cls, var_name: str, default: Any = None, type: type = str):
         if var_name in environ:
@@ -36,6 +39,24 @@ class Utils:
     @classmethod
     def envvarExists(cls, var_name: str) -> bool:
         return var_name in environ
+
+    @classmethod
+    def checkRequiredEnvVar(cls, folder: str):
+        result = subprocess.run(
+            f"sh ./scripts/list_required_parameters.sh {folder}".split(),
+            capture_output=True,
+            text=True,
+        ).stdout
+
+        all_set_flag = True
+        for var in result.splitlines():
+            exists = Utils.envvarExists(var)
+            all_set_flag *= exists
+
+            # print var with a leading check mark if it exists or red X (emoji) if it doesn't
+            cls().info(f"{'✅' if exists else '❌'} {var}")
+
+        return all_set_flag
 
     @classmethod
     def nodesAddresses(cls, address_prefix: str, keyenv: str) -> tuple[list[str], str]:

--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -34,6 +34,10 @@ class Utils:
         return dict(sorted(var_dict.items()))
 
     @classmethod
+    def envvarExists(cls, var_name: str) -> bool:
+        return var_name in environ
+
+    @classmethod
     def nodesAddresses(cls, address_prefix: str, keyenv: str) -> tuple[list[str], str]:
         addresses = Utils.envvarWithPrefix(address_prefix).values()
         key = Utils.envvar(keyenv)

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -35,7 +35,7 @@ NEXT_DISTRIBUTION_EPOCH = Gauge("next_distribution_epoch", "Next distribution (e
 TOTAL_FUNDING = Gauge("ct_total_funding", "Total funding")
 
 
-class CTCore(Base):
+class Core(Base):
     flag_prefix = "CORE_"
 
     def __init__(self):

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -159,8 +159,8 @@ class Core(Base):
 
         while True:
             query = self.params.subgraph.safes_balance_query
-            query = query.replace("$first", f"{self.params.subgraph.pagination_size}")
-            query = query.replace("$skip", f"{skip}")
+            query = query.replace("valfirst", f"{self.params.subgraph.pagination_size}")
+            query = query.replace("valskip", f"{skip}")
 
             _, response = await Utils.httpPOST(
                 self.subgraph_safes_balance_url(self.safes_balance_subgraph_type),
@@ -335,8 +335,8 @@ class Core(Base):
                 continue
 
             query: str = self.params.subgraph.wxhopr_txs_query
-            query = query.replace("$from", f'"{from_address}"')
-            query = query.replace("$to", f'"{to_address}"')
+            query = query.replace("valfrom", f'"{from_address}"')
+            query = query.replace("valto", f'"{to_address}"')
 
             _, response = await Utils.httpPOST(
                 self.params.subgraph.wxhopr_txs_url, {"query": query}

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -36,8 +36,6 @@ TOTAL_FUNDING = Gauge("ct_total_funding", "Total funding")
 
 
 class Core(Base):
-    flag_prefix = "CORE_"
-
     def __init__(self):
         super().__init__()
 
@@ -178,7 +176,6 @@ class Core(Base):
 
             safes.extend(response["data"]["safes"])
 
-            print(f"{response['data']['safes']=}")
             if len(response["data"]["safes"]) >= self.params.subgraph.pagination_size:
                 skip += self.params.subgraph.pagination_size
             else:
@@ -242,7 +239,6 @@ class Core(Base):
         Utils.allowManyNodePerSafe(eligibles)
         self.debug(f"Allowed many nodes per safe ({len(eligibles)} entries).")
 
-        print(f"{self.params.economic_model.min_safe_allowance=}")
         low_allowance_addresses = [
             peer.address
             for peer in eligibles

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -58,8 +58,6 @@ TOTAL_CHANNEL_FUNDS = Gauge(
 
 
 class Node(Base):
-    flag_prefix = "NODE_"
-
     def __init__(self, url: str, key: str):
         super().__init__()
 

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -84,7 +84,7 @@ class Node(Base):
 
     @property
     def print_prefix(self):
-        return '.'.join(self.url.split("//")[-1].split(".")[:2])
+        return ".".join(self.url.split("//")[-1].split(".")[:2])
 
     async def _retrieve_address(self):
         address = await self.api.get_address("all")

--- a/ct-app/get_params.sh
+++ b/ct-app/get_params.sh
@@ -1,14 +1,34 @@
-file_path="./core/node.py"
 
-if [ -z "$file_path" ]; then
-    echo "Usage: $0 <file>"
+folder_path=$1
+
+if [ -z "$folder_path" ]; then
+    echo "Usage: $0 <folder>"
     exit 1
 fi
 
-# Use grep to find lines containing "params" or "self.params" at the beginning of a word
-# -o option only prints the matched parts of a line
-variable_list=$(grep -oE '\b(self\.)?params[a-zA-Z0-9_]*' "$file_path")
+all_variables=""
 
-# Print the list of variables
-echo "List of variables:"
-echo "$variable_list"
+
+# Use find to get a list of files in the specified folder
+for file in "$folder_path"/*; do
+    if [ -f "$file" ]; then        
+        # Use grep to find lines containing "params" or "self.params" at the beginning of a word
+        # -o option only prints the matched parts of a line
+        variable_list=$(grep -oE '\b(self\.)?params[[:alnum:]._]*\b' "$file" | awk '{sub(/(self\.)?params/, ""); sub(/^\.+/, ""); if ($0 != "") print}')
+
+        all_variables+="$variable_list"
+    fi
+done
+
+unique_variables=$(echo "$all_variables" | tr ' ' '\n' | sort -u)
+
+IFS=$'\n' # Set Internal Field Separator to newline to iterate over lines
+
+for variable in $unique_variables; do
+    # Apply your own logic here
+    # Example: Print the variable with some custom message
+
+    var="$(echo $variable | tr a-z A-Z | tr . _)"
+
+    echo "$var"
+done

--- a/ct-app/get_params.sh
+++ b/ct-app/get_params.sh
@@ -1,0 +1,14 @@
+file_path="./core/node.py"
+
+if [ -z "$file_path" ]; then
+    echo "Usage: $0 <file>"
+    exit 1
+fi
+
+# Use grep to find lines containing "params" or "self.params" at the beginning of a word
+# -o option only prints the matched parts of a line
+variable_list=$(grep -oE '\b(self\.)?params[a-zA-Z0-9_]*' "$file_path")
+
+# Print the list of variables
+echo "List of variables:"
+echo "$variable_list"

--- a/ct-app/get_params.sh
+++ b/ct-app/get_params.sh
@@ -1,8 +1,5 @@
-
-folder_path=$1
-
-if [ -z "$folder_path" ]; then
-    echo "Usage: $0 <folder>"
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <folder1> <folder2> ..."
     exit 1
 fi
 
@@ -10,14 +7,16 @@ all_variables=""
 
 
 # Use find to get a list of files in the specified folder
-for file in "$folder_path"/*; do
-    if [ -f "$file" ]; then        
-        # Use grep to find lines containing "params" or "self.params" at the beginning of a word
-        # -o option only prints the matched parts of a line
-        variable_list=$(grep -oE '\b(self\.)?params[[:alnum:]._]*\b' "$file" | awk '{sub(/(self\.)?params/, ""); sub(/^\.+/, ""); if ($0 != "") print}')
+for folder in "$@"; do
+    for file in "$folder"/*; do
+        if [ -f "$file" ]; then        
+            # Use grep to find lines containing "params" or "self.params" at the beginning of a word
+            # -o option only prints the matched parts of a line
+            variable_list=$(grep -oE '\b(self\.)?params[[:alnum:]._]*\b' "$file" | awk '{sub(/(self\.)?params/, ""); sub(/^\.+/, ""); if ($0 != "") print}')
 
-        all_variables+="$variable_list"
-    fi
+            all_variables+="\n$variable_list"
+        fi
+    done
 done
 
 unique_variables=$(echo "$all_variables" | tr ' ' '\n' | sort -u)

--- a/ct-app/namtsop/namtsop_tasks.py
+++ b/ct-app/namtsop/namtsop_tasks.py
@@ -3,12 +3,15 @@ from datetime import datetime
 
 from celery import Celery
 from core.components.parameters import Parameters
+from core.components.utils import Utils
 from database import DatabaseConnection, Reward
 
 log = logging.getLogger()
 
 params = Parameters()("RABBITMQ_")
 
+if not Utils.checkRequiredEnvVar("namtsop"):
+    exit(1)
 
 app = Celery(
     name=params.rabbitmq.project_name,

--- a/ct-app/postman/postman_tasks.py
+++ b/ct-app/postman/postman_tasks.py
@@ -16,6 +16,8 @@ log.setLevel(logging.INFO)
 
 params = Parameters()("PARAM_", "RABBITMQ_")
 
+if not Utils.checkRequiredEnvVar("postman"):
+    exit(1)
 
 app = Celery(
     name=params.rabbitmq.project_name,

--- a/ct-app/scripts/list_required_parameters.sh
+++ b/ct-app/scripts/list_required_parameters.sh
@@ -5,13 +5,9 @@ fi
 
 all_variables=""
 
-
-# Use find to get a list of files in the specified folder
 for folder in "$@"; do
     for file in "$folder"/*; do
         if [ -f "$file" ]; then        
-            # Use grep to find lines containing "params" or "self.params" at the beginning of a word
-            # -o option only prints the matched parts of a line
             variable_list=$(grep -oE '\b(self\.)?params[[:alnum:]._]*\b' "$file" | awk '{sub(/(self\.)?params/, ""); sub(/^\.+/, ""); if ($0 != "") print}')
 
             all_variables+="\n$variable_list"
@@ -22,12 +18,6 @@ done
 unique_variables=$(echo "$all_variables" | tr ' ' '\n' | sort -u)
 
 IFS=$'\n' # Set Internal Field Separator to newline to iterate over lines
-
 for variable in $unique_variables; do
-    # Apply your own logic here
-    # Example: Print the variable with some custom message
-
-    var="$(echo $variable | tr a-z A-Z | tr . _)"
-
-    echo "$var"
+    echo $(echo $variable | tr a-z A-Z | tr . _)
 done

--- a/ct-app/test/components/test_decorators.py
+++ b/ct-app/test/components/test_decorators.py
@@ -9,8 +9,6 @@ from core.components.lockedvar import LockedVar
 
 
 class FooClass(Base):
-    flag_prefix = "FOO_"
-
     def __init__(self):
         super().__init__()
         self.connected = LockedVar("connected", False)

--- a/ct-app/test/components/test_decorators.py
+++ b/ct-app/test/components/test_decorators.py
@@ -1,10 +1,10 @@
 import asyncio
 import os
-from core.components.flags import Flags
 
 import pytest
 from core.components.baseclass import Base
 from core.components.decorators import connectguard, flagguard, formalin
+from core.components.flags import Flags
 from core.components.lockedvar import LockedVar
 
 
@@ -49,11 +49,12 @@ async def test_connectguard(foo_class: FooClass):
     res = await foo_class.foo_connectguard_func()
     assert res is True
 
+
 @pytest.mark.asyncio
 async def test_flagguard(foo_class: FooClass):
     res = await foo_class.foo_flagguard_func()
     assert res is None
-    
+
     # delete flag cache so that new flags are retrieved from env
     Flags._cache_flags = None
 
@@ -63,12 +64,13 @@ async def test_flagguard(foo_class: FooClass):
 
     del os.environ["FLAG_FOO_FOO_FLAGGUARD_FUNC"]
 
+
 @pytest.mark.asyncio
 async def test_formalin(foo_class: FooClass):
     # reset flag cache and instance counter
     Flags._cache_flags = None
     foo_class.counter = 0
-    # # # # # # # # # # # # # # # # # # # # 
+    # # # # # # # # # # # # # # # # # # # #
 
     # should run only once
     os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"] = "0"
@@ -79,25 +81,24 @@ async def test_formalin(foo_class: FooClass):
     foo_class.started = False
     await asyncio.sleep(0.5)
 
-    assert foo_class.counter == 1 # counter increased only once
+    assert foo_class.counter == 1  # counter increased only once
 
     del os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"]
 
     # reset flag cache and instance counter
     Flags._cache_flags = None
     foo_class.counter = 0
-    # # # # # # # # # # # # # # # # # # # # 
+    # # # # # # # # # # # # # # # # # # # #
 
     # should run twice (every 0.5s in 1.1s)
     os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"] = "0.5"
-    
+
     foo_class.started = True
     asyncio.create_task(foo_class.foo_formalin_func())
     await asyncio.sleep(1.1)
     foo_class.started = False
     await asyncio.sleep(0.5)
-    
-    assert foo_class.counter == 2 # counter increased twice
-    
-    del os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"]
 
+    assert foo_class.counter == 2  # counter increased twice
+
+    del os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"]

--- a/ct-app/test/components/test_decorators.py
+++ b/ct-app/test/components/test_decorators.py
@@ -58,11 +58,11 @@ async def test_flagguard(foo_class: FooClass):
     # delete flag cache so that new flags are retrieved from env
     Flags._cache_flags = None
 
-    os.environ["FLAG_FOO_FOO_FLAGGUARD_FUNC"] = "1"
+    os.environ["FLAG_FOOCLASS_FOO_FLAGGUARD_FUNC"] = "1"
     res = await foo_class.foo_flagguard_func()
     assert res is True
 
-    del os.environ["FLAG_FOO_FOO_FLAGGUARD_FUNC"]
+    del os.environ["FLAG_FOOCLASS_FOO_FLAGGUARD_FUNC"]
 
 
 @pytest.mark.asyncio
@@ -73,7 +73,7 @@ async def test_formalin(foo_class: FooClass):
     # # # # # # # # # # # # # # # # # # # #
 
     # should run only once
-    os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"] = "0"
+    os.environ["FLAG_FOOCLASS_FOO_FORMALIN_FUNC"] = "0"
 
     foo_class.started = True
     asyncio.create_task(foo_class.foo_formalin_func())
@@ -83,7 +83,7 @@ async def test_formalin(foo_class: FooClass):
 
     assert foo_class.counter == 1  # counter increased only once
 
-    del os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"]
+    del os.environ["FLAG_FOOCLASS_FOO_FORMALIN_FUNC"]
 
     # reset flag cache and instance counter
     Flags._cache_flags = None
@@ -91,7 +91,7 @@ async def test_formalin(foo_class: FooClass):
     # # # # # # # # # # # # # # # # # # # #
 
     # should run twice (every 0.5s in 1.1s)
-    os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"] = "0.5"
+    os.environ["FLAG_FOOCLASS_FOO_FORMALIN_FUNC"] = "0.5"
 
     foo_class.started = True
     asyncio.create_task(foo_class.foo_formalin_func())
@@ -101,4 +101,4 @@ async def test_formalin(foo_class: FooClass):
 
     assert foo_class.counter == 2  # counter increased twice
 
-    del os.environ["FLAG_FOO_FOO_FORMALIN_FUNC"]
+    del os.environ["FLAG_FOOCLASS_FOO_FORMALIN_FUNC"]


### PR DESCRIPTION
CT v2.* heavily relies on environment variables. Those variables are used are either optional flags or mandatory parameters. 

On runtime, a parser goes through the specified environment variables and create a parameter object containing all environment values that match a given pattern (`PARAM_` + `<category>` + `<var_name>`). 
This automatic parsing allows the developer to add some parameters in the code by accessing them through the dynamically created parameter instance, without prior checks. This way to deal with environment variable is nice, but also has a great drawback: a given variable may not be available in the environment, and the app would only now it is missing on runtime. 

This PR adds a prior check, still on runtime but at the very start of any module, that all the required parameters are in the environment. This is done thanks to a bash script that parses a given folder (or list of folders) and look for all required parameters. Everything following `self.params` or `params` is considered as a parameter.
Example: if the bash script sees `self.params.core.min_count`, it will check that the variable `PARAM_CORE_MIN_COUNT` is set. Same thing for `params.threshold`: if `PARAM_THRESHOLD` doesn't exist in the environment, the program won't start and a message in the logs will show that the parameter is missing. 