### PR TITLE
Update check_subgraph_urls to handle empty response data

### DIFF
--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -66,7 +66,7 @@ class Utils(Base):
         return list(addresses), key
 
     @classmethod
-    async def httpPOST(cls, url, data):
+    async def httpPOST(cls, url, data) -> tuple[int, dict]:
         async def post(session: ClientSession, url: str, data: dict):
             async with session.post(url, json=data) as response:
                 status = response.status
@@ -112,7 +112,11 @@ class Utils(Base):
 
             peer.safe_address = subgraph_entry.safe_address
             peer.safe_balance = subgraph_entry.wxHoprBalance
-            peer.safe_allowance = float(subgraph_entry.safe_allowance)
+
+            if subgraph_entry.safe_allowance:
+                peer.safe_allowance = float(subgraph_entry.safe_allowance)
+            else:
+                peer.safe_allowance = None
 
             if peer.complete and peer.address in network_addresses:
                 merged_result.append(peer)

--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -113,7 +113,7 @@ class Utils(Base):
             peer.safe_address = subgraph_entry.safe_address
             peer.safe_balance = subgraph_entry.wxHoprBalance
 
-            if subgraph_entry.safe_allowance:
+            if subgraph_entry.safe_allowance is not None:
                 peer.safe_allowance = float(subgraph_entry.safe_allowance)
             else:
                 peer.safe_allowance = None

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -115,7 +115,7 @@ class Core(Base):
     async def check_subgraph_urls(self):
         data = {
             "query": self.params.subgraph.safes_balance_query,
-            "variables": {"first": 1, "skip": 0},
+            "variables": {"first": 5, "skip": 0},
         }
 
         for subgraph in SubgraphType.callables():
@@ -123,7 +123,7 @@ class Core(Base):
                 self.subgraph_safes_balance_url(subgraph), data
             )
 
-            if not response:
+            if not response or response.get("data", {}).get("safes", None) is None:
                 continue
 
             SUBGRAPH_CALLS.labels(subgraph.value).inc()


### PR DESCRIPTION
A subgraph endpoint rotation is done between the centralized and decentralized (used by default) in case one or the other is failing to return data.

Until now, we were only checking that the endpoint returns something (it happens that the endpoint is even not reachable) but this is not enough. In case a error is thrown by the server, it will be counted as a successful response, which would not trigger the rotation. 

Now, when check an endpoint, a check that the result structure is correct is done. This will force the rotation on error thrown.