### PR TITLE
Fixing node eligibility

### DIFF
--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -180,15 +180,17 @@ class Utils(Base):
         ]
 
         # remove entries from the list
+        excluded: list[Peer] = []
         for index in sorted(indexes_to_remove, reverse=True):
-            peers.pop(index)
+            peer: Peer = peers.pop(index)
+            excluded.append(peer)
 
         # compute ct probability
         total_tf_stake = sum(peer.transformed_stake for peer in peers)
         for peer in peers:
             peer.reward_probability = peer.transformed_stake / total_tf_stake
 
-        return indexes_to_remove
+        return excluded
 
     @classmethod
     def jsonFromGCP(cls, bucket_name, blob_name, schema=None):

--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -143,11 +143,11 @@ class Peer:
         # check that none of the attributes are None
         return all(
             [
-                self.address,
-                self.channel_balance,
-                self.safe_address,
-                self.safe_balance,
-                self.safe_allowance,
+                self.address is not None,
+                self.channel_balance is not None,
+                self.safe_address is not None,
+                self.safe_balance is not None,
+                self.safe_allowance is not None,
             ]
         )
 


### PR DESCRIPTION
Before, checking that a node was eligible was done by computing this:
```python
all([
    self.address,
    self.channel_balance,
    self.safe_address,
    self.safe_balance,
    self.safe_allowance,
])
```
which could be wrong if any of the values were equal to `0`.
However, on this step we only need to know if the values were set to something different than `None`. This has been changed in this PR.