### PR TITLE
Fix core too strongly bound to underlying nodes

### DIFF
--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -99,6 +99,12 @@ class Core(Base):
 
     async def _retrieve_address(self):
         addresses = await self.api.get_address("all")
+        if not addresses:
+            self.warning("No address retrieved from node.")
+            return
+        if "hopr" not in addresses or "native" not in addresses:
+            self.warning("Invalid address retrieved from node.")
+            return
         self.address = Address(addresses["hopr"], addresses["native"])
 
     @flagguard
@@ -343,7 +349,8 @@ class Core(Base):
     async def get_fundings(self):
         from_address = self.params.subgraph.from_address
         ct_safe_addresses = {
-            (await node.api.node_info()).node_safe for node in self.network_nodes
+            getattr(await node.api.node_info(), "node_safe", None)
+            for node in self.network_nodes
         }
 
         transactions = []

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -245,7 +245,9 @@ class Node(Base):
         ]
 
         low_balances = [
-            c for c in out_opens if int(c.balance)/1e18 <= self.params.channel.min_balance
+            c
+            for c in out_opens
+            if int(c.balance) / 1e18 <= self.params.channel.min_balance
         ]
 
         self.debug(f"Low balance channels: {len(low_balances)}")
@@ -255,7 +257,7 @@ class Node(Base):
         for channel in low_balances:
             if channel.destination_peer_id in peer_ids:
                 ok = await self.api.fund_channel(
-                    channel.channel_id, self.params.channel.funding_amount*1e18
+                    channel.channel_id, self.params.channel.funding_amount * 1e18
                 )
                 if ok:
                     self.debug(f"Funded channel {channel.channel_id}")


### PR DESCRIPTION
CT Core relies on nodes, more precisely on node's API's. In case a node get unreachable, a call to it's API will fail. This behaviour is expected, but needs some attention. 
If a result of the API call is a dictionary, accessing the content of this dictionary needs to be done in a safe way.

This was done most of the time, but some remaining parts of the codes were still using API results without checking that the result is indeed available.

This PR fixes this issue (#459)