### PR TITLE
Fix `HoprdAPI` token handling

### DIFF
--- a/ct-app/core/components/hoprd_api.py
+++ b/ct-app/core/components/hoprd_api.py
@@ -29,9 +29,12 @@ class HoprdAPI(Base):
     """
 
     def __init__(self, url: str, token: str):
+        def _refresh_token_hook(self):
+            self.api_key["x-auth-token"] = token
+
         self.configuration = Configuration()
         self.configuration.host = f"{url}/api/v3"
-        self.configuration.api_key["x-auth-token"] = token
+        self.configuration.refresh_api_key_hook = _refresh_token_hook
 
     @property
     def print_prefix(self) -> str:

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/hoprnet/hoprd-sdk-python.git@main
+git+https://github.com/hoprnet/hoprd-sdk-python.git@master
 aiohttp==3.8.4
 jsonschema==4.17.3
 numpy==1.25.0


### PR DESCRIPTION
With the previous implementation, `HoprdAPI` was using the token provided on the instantiation of the last instance for all instances.
A workaround is to update the token with a hook at each call, to be sure that for every node, the correct credentials are used.