### PR TITLE
Peer version not propagated when merging data sources

### DIFF
--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -101,6 +101,7 @@ class Utils(Base):
         merged_result: list[Peer] = []
 
         network_addresses = [p.address for p in peers_list]
+        peer_versions = {p.address: p.version for p in peers_list}
 
         # Merge based on peer ID with the channel topology as the baseline
         for topology_entry in topology_list:
@@ -121,6 +122,7 @@ class Utils(Base):
                 peer.safe_allowance = None
 
             if peer.complete and peer.address in network_addresses:
+                peer.version = peer_versions[peer.address]
                 merged_result.append(peer)
 
         return merged_result

--- a/ct-app/core/model/topology_entry.py
+++ b/ct-app/core/model/topology_entry.py
@@ -19,6 +19,6 @@ class TopologyEntry:
         )
 
     def to_peer(self) -> Peer:
-        peer = Peer(self.peer_id, self.node_address, "v0.0.0")
+        peer = Peer(self.peer_id, self.node_address, "0.0.0")
         peer.channel_balance = self.channels_balance
         return peer

--- a/ct-app/test/model/test_peer.py
+++ b/ct-app/test/model/test_peer.py
@@ -5,26 +5,30 @@ from packaging.version import Version
 def test_peer_version():
     peer = Peer("some_id", "some_address", "0.0.1")
 
-    peer.version = "v0.1.0-rc.1"
-    assert peer.version_is_old("v0.1.0-rc.2")
-    assert peer.version_is_old(Version("v0.1.0-rc.2"))
+    peer.version = "0.1.0-rc.1"
+    assert peer.version_is_old("0.1.0-rc.2")
+    assert peer.version_is_old(Version("0.1.0-rc.2"))
 
-    peer.version = "v0.1.0-rc.1"
-    assert not peer.version_is_old("v0.1.0-rc.0")
-    assert not peer.version_is_old(Version("v0.1.0-rc.0"))
+    peer.version = "0.1.0-rc.1"
+    assert not peer.version_is_old("0.1.0-rc.0")
+    assert not peer.version_is_old(Version("0.1.0-rc.0"))
 
-    peer.version = "v0.1.1"
-    assert not peer.version_is_old("v0.1.0-rc.3")
-    assert not peer.version_is_old(Version("v0.1.0-rc.3"))
+    peer.version = "0.1.1"
+    assert not peer.version_is_old("0.1.0-rc.3")
+    assert not peer.version_is_old(Version("0.1.0-rc.3"))
 
-    peer.version = "v0.1.0-rc.1"
-    assert not peer.version_is_old("v0.1.0-rc.1")
-    assert not peer.version_is_old(Version("v0.1.0-rc.1"))
+    peer.version = "0.1.0-rc.1"
+    assert not peer.version_is_old("0.1.0-rc.1")
+    assert not peer.version_is_old(Version("0.1.0-rc.1"))
 
-    peer.version = "v2.0"
-    assert not peer.version_is_old("v2.0")
-    assert not peer.version_is_old(Version("v2.0"))
+    peer.version = "2.0"
+    assert not peer.version_is_old("2.0")
+    assert not peer.version_is_old(Version("2.0"))
 
-    peer.version = "v2.0"
-    assert peer.version_is_old("v2.1")
-    assert peer.version_is_old(Version("v2.1"))
+    peer.version = "2.0"
+    assert peer.version_is_old("2.1")
+    assert peer.version_is_old(Version("2.1"))
+
+    peer.version = "2.0.7"
+    assert not peer.version_is_old("2.0.7")
+    assert not peer.version_is_old(Version("2.0.7"))


### PR DESCRIPTION
Version (`0.0.0`) was set in the topology class as default, waiting for an update from the peer list when merging data sources. This update wasn't done, thus all peers appeared to be running on `0.0.0` instead of the real node version.