### PR TITLE
Upgrade to version "saint-louis"

### DIFF
--- a/helm/values-staging-blue.yaml
+++ b/helm/values-staging-blue.yaml
@@ -1,6 +1,6 @@
 replicas: 5
 network: rotsee
-version: 2.1.0-rc.4-pr.6206
+version: saint-louis
 
 config: |
   hopr:

--- a/helm/values-staging-green.yaml
+++ b/helm/values-staging-green.yaml
@@ -1,6 +1,6 @@
 replicas: 0
 network: rotsee
-version: 2.1.0-rc.3
+version: saint-louis
 
 config: |
   hopr:


### PR DESCRIPTION
Upgrade to maintenance tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the version identifier in staging configurations to "saint-louis" for both blue and green environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->