### PR TITLE
Create automatic database backups

### DIFF
--- a/helm/ctdapp/templates/cronjob-backup.yaml
+++ b/helm/ctdapp/templates/cronjob-backup.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: phttp-backup
+  name: ctdapp-backup
 spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1

--- a/helm/ctdapp/templates/cronjob-backup.yaml
+++ b/helm/ctdapp/templates/cronjob-backup.yaml
@@ -1,0 +1,55 @@
+---
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: phttp-backup
+spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  schedule: "{{ .Values.backup.schedule }}"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          initContainers:
+          - name: dump
+            image: postgres:15-bookworm
+            command:
+              - /bin/bash
+              - -c
+              - |
+                set -e
+                TIMESTAMP=$(date +%Y%m%d%H%M%S)
+                echo Starting full backup of database ${PGDATABASE} at $(date)
+                pg_dump --no-privileges --no-owner --format=custom --compress=9 --file=/backup/ctdapp-${TIMESTAMP}.dump
+                echo Backup finished at $(date)
+            envFrom:
+            - secretRef:
+                name: postgres
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          containers:
+          - name: backup
+            image: gcr.io/google.com/cloudsdktool/google-cloud-cli:475.0.0
+            command:
+              - /bin/bash
+              - -c
+              - |              
+                echo Copying the backup to the bucket
+                gsutil cp /backup/*.dump gs://hoprnet-backup-{{ .Values.environmentName }}/postgres/ctdapp/
+                echo Keep only the 7 most recent backups
+                gsutil ls gs://hoprnet-backup-{{ .Values.environmentName }}/postgres/ctdapp | sort -r | tail -n +8 | xargs -I {} gsutil rm {}
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          volumes:
+          - name: backup
+            emptyDir: {}
+          restartPolicy: OnFailure
+          serviceAccount: sa-backup
+{{- end }}

--- a/helm/ctdapp/templates/serviceaccount-backup.yaml
+++ b/helm/ctdapp/templates/serviceaccount-backup.yaml
@@ -1,0 +1,10 @@
+---
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  name: sa-backup
+  annotations:
+    iam.gke.io/gcp-service-account: "backup@hopr-{{ .Values.environmentName }}.iam.gserviceaccount.com"
+{{- end }}%  

--- a/helm/ctdapp/templates/serviceaccount-backup.yaml
+++ b/helm/ctdapp/templates/serviceaccount-backup.yaml
@@ -7,4 +7,4 @@ metadata:
   name: sa-backup
   annotations:
     iam.gke.io/gcp-service-account: "backup@hopr-{{ .Values.environmentName }}.iam.gserviceaccount.com"
-{{- end }}%  
+{{- end }}

--- a/helm/ctdapp/values.yaml
+++ b/helm/ctdapp/values.yaml
@@ -1,4 +1,7 @@
 environmentName: ""
+backup:
+  enabled: false
+  schedule:
 ctdapp:
 
   nameOverride: ""

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,6 +5,10 @@ blue-nodes:
 green-nodes:
   enabled: false
 
+backup:
+  enabled: true
+  schedule: 30 21 * * * # 9:30 PM UTC
+
 ctdapp:
   core:
     replicas: 1

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -5,6 +5,10 @@ blue-nodes:
 green-nodes:
   enabled: true
 
+backup:
+  enabled: true
+  schedule: 30 21 * * * # 9:30 PM UTC
+
 ctdapp:
   core:
     replicas: 0


### PR DESCRIPTION
Create a cronjob that execute a backup of the database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced scheduled database backups with a new CronJob configuration.
  - Added a ServiceAccount for managing backup permissions.
  - Configurable backup settings in Helm charts for different environments (staging and production).

- **Configuration**
  - New `backup` section in `values.yaml` with an `enabled` flag and `schedule` field.
  - Default backup schedule set to 9:30 PM UTC for staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->