### PR TITLE
Handle additional error cases in GraphQLProvider

### DIFF
--- a/ct-app/core/components/graphql_providers.py
+++ b/ct-app/core/components/graphql_providers.py
@@ -42,6 +42,10 @@ class GraphQLProvider(Base):
             raise ProviderError(err.errors[0]["message"])
         except TimeoutError as err:
             self.error(f"Timeout error: {err}")
+        except ProviderError as err:
+            self.error(f"ProviderError error: {err}")
+        except Exception as err:
+            self.error(f"Unknown error: {err}")
 
     async def _test_query(self, key: str, **kwargs) -> bool:
         """


### PR DESCRIPTION
A Subgraph started to throw unseen error until now, as `ProviderError`s. Those are now catched in addition to the default error handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for GraphQL providers to provide clearer error messages for `ProviderError` and other exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->