### PR TITLE
Update SAFES_BALANCE_URL in secret-subgraph.yaml

### DIFF
--- a/helm/ctdapp/templates/secret-subgraph.yaml
+++ b/helm/ctdapp/templates/secret-subgraph.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   SUBGRAPH_STAKING_URL: {{ .Values.ctdapp.subgraph.stakingUrl | b64enc }}
   SUBGRAPH_STAKING_URL_BACKUP: {{ .Values.ctdapp.subgraph.stakingUrlBackup | b64enc }}
-  SUBGRAPH_SAFES_BALANCE_URL: {{ .Values.ctdapp.subgraph.safesBalanceUrl | b64enc }}
+  SUBGRAPH_SAFES_BALANCE_URL: {{ .Values.ctdapp.subgraph.safesBalanceUrlBackup | b64enc }}
   SUBGRAPH_SAFES_BALANCE_URL_BACKUP: {{ .Values.ctdapp.subgraph.safesBalanceUrlBackup | b64enc }}
   SUBGRAPH_WXHOPR_TXS_URL: {{ .Values.ctdapp.subgraph.wxhoprTxsUrl | b64enc }}
   SUBGRAPH_WXHOPR_TXS_URL_BACKUP: {{ .Values.ctdapp.subgraph.wxhoprTxsUrlBackup | b64enc }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the configuration to use the backup URL for Safes Balance, ensuring more reliable access and reducing downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->