### PR TITLE
Fix version parsing when returned value is `UNKNOWN`

### DIFF
--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -49,7 +49,7 @@ class Peer:
         if not isinstance(value, Version):
             try:
                 value = Version(value)
-            except:
+            except Exception:
                 value = Version("0.0.0")
 
         self._version = value

--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -46,8 +46,11 @@ class Peer:
 
     @version.setter
     def version(self, value: str or Version):
-        if isinstance(value, str):
-            value = Version(value)
+        if not isinstance(value, Version):
+            try:
+                value = Version(value)
+            except:
+                value = Version("0.0.0")
 
         self._version = value
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced version property handling to ensure robustness. Non-`Version` inputs are now converted to `Version` objects, defaulting to "0.0.0" if conversion fails. This improves stability and prevents potential issues with invalid version formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->