### PR TITLE
Use local param file instead of GCP file when distributing rewards

### DIFF
--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -381,9 +381,7 @@ class Core(Base):
         Distributes the rewards to the eligible peers, based on the economic model.
         """
 
-        model = EconomicModel.fromGCPFile(
-            self.params.gcp.bucket, self.params.economicModel.filename
-        )
+        model = EconomicModel.fromParameters(self.params.economicModel)
         model.budget.ticket_price = await self.ticket_price.get()
 
         delay = Utils.nextDelayInSeconds(model.delay_between_distributions)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the reward distribution method to directly use parameters instead of a GCP file for the economic model. This change improves efficiency and simplifies configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->