### PR TITLE
Fix peers using same upper-bound

### DIFF
--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 import random
 
 from celery import Celery
@@ -346,7 +347,7 @@ class Core(Base):
         redeemed_rewards = await self.peer_rewards.get()
 
         for peer in eligibles:
-            peer.economic_model = model
+            peer.economic_model = deepcopy(model)
             peer.economic_model.coefficients.c += redeemed_rewards.get(peer.address.address,0.0)
             peer.max_apr = self.params.economicModel.maxAPRPercentage
 


### PR DESCRIPTION
When updating economic model upper-bound, every peer was sharing the same economic model, and thus the same upper bound. Now, a deep-copy of the model imported from parameters is done before modifying upper-bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data handling by using deep copy for economic models, ensuring changes to peer economic models do not affect the original model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->