### PR TITLE
Fix: use per-distribution tag per peer

### DIFF
--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -500,10 +500,10 @@ class Core(Base):
                 "expected": peer.message_count_for_reward,
                 "remaining": peer.message_count_for_reward,
                 "issued": 0,
-                "tag": DBUtils.peerIDToInt(peer.address.id, self.params.pg),
+                "tag": idx,
                 "ticket-price": peer.economic_model.budget.ticket_price,
-            }  # will be retrieved from the API once the endpoint is available in 2.1
-            for peer in peers
+            }
+            for idx, peer in enumerate(peers)
         }
 
         self.debug(f"Distribution summary: {reward_per_peer}")

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -511,7 +511,7 @@ class Core(Base):
             iteration < max_iterations and _total_messages_to_send(reward_per_peer) > 0
         ):
             self.debug("Splitting peers into groups")
-            peers_groups = Utils.splitDict(reward_per_peer, len(reward_per_peer))
+            peers_groups = Utils.splitDict(reward_per_peer, len(self.nodes))
 
             # send rewards to peers
             self.debug("Sending rewards to peers")

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any
 
-from database import Utils as DBUtils
 from database.database_connection import DatabaseConnection
 from database.models import Reward
 from prometheus_client import Gauge

--- a/ct-app/scripts/core_prod_config.yaml
+++ b/ct-app/scripts/core_prod_config.yaml
@@ -65,8 +65,8 @@ economicModel:
 # =============================================================================
 distribution:
   minEligiblePeers: 100
-  messageDeliveryDelay: 5.0
-  delayBetweenTwoMessages: 0.0005
+  messageDeliveryDelay: 10.0
+  delayBetweenTwoMessages: 0.001
   maxIterations: 3
 
 # =============================================================================

--- a/ct-app/scripts/core_prod_config.yaml
+++ b/ct-app/scripts/core_prod_config.yaml
@@ -65,8 +65,8 @@ economicModel:
 # =============================================================================
 distribution:
   minEligiblePeers: 100
-  messageDeliveryDelay: 10.0
-  delayBetweenTwoMessages: 0.001
+  messageDeliveryDelay: 5.0
+  delayBetweenTwoMessages: 0.0005
   maxIterations: 3
 
 # =============================================================================

--- a/ct-app/test/conftest.py
+++ b/ct-app/test/conftest.py
@@ -9,7 +9,6 @@ from core.model.economic_model import Budget
 from core.model.economic_model import Coefficients as Coefficients
 from core.model.economic_model import EconomicModel, Equation, Equations
 from core.model.peer import Peer
-from database import Utils as DBUtils
 from hoprd_sdk.models import ChannelInfoResponse, NodeChannelsResponse
 from pytest_mock import MockerFixture
 

--- a/ct-app/test/conftest.py
+++ b/ct-app/test/conftest.py
@@ -204,8 +204,6 @@ def channels(peers: list[Peer]) -> NodeChannelsResponse:
 async def core(mocker: MockerFixture, nodes: list[Node]) -> Core:
     core = Core()
 
-    mocker.patch.object(DBUtils, "peerIDToInt", return_value=0)
-
     params = Parameters()
     with open("./test/test_config.yaml", "r") as file:
         params.parse(yaml.safe_load(file))


### PR DESCRIPTION
Before, each peer was assigned a fix tag before relaying CT. The tag was stored in a DB, from where it was pulled again at the next distribution.
Now, the tag is set for a distribution, and will be changed at every distribution. This avoids having a DB call that was actually unnecessary. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified peer indexing logic for improved code readability.
- **Tests**
	- Removed unnecessary imports and mock patches for cleaner test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->