### PR TITLE
Ensure no multi-line logs are generated

### DIFF
--- a/ct-app/core/components/baseclass.py
+++ b/ct-app/core/components/baseclass.py
@@ -30,7 +30,7 @@ class Base:
         return cls.__name__.lower()
 
     def __format(self, message: str):
-        return f"{self.print_prefix} | {message}"
+        return f"{self.print_prefix} | {message}".replace("\n", "")
 
     def debug(self, message: str):
         self.logger.debug(self.__format(message))


### PR DESCRIPTION
This easy PR ensures that every generated log is made out of a single line.

All the request objects from the HOPRd Python SDK define a `__str__` method to show the content of a request. The output format of those methods are dictionaries generated so that it is easy to read from the command line, but then include some `\n` messing up with logs.

The fix proposed here ensures every single log generated, not only the ones including HOPRd SDK objects, are printed as a single line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message formatting by removing unwanted newline characters from formatted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->