### PR TITLE
Refactor split_stake property to handle None values for yearly_message

### DIFF
--- a/ct-app/core/model/peer.py
+++ b/ct-app/core/model/peer.py
@@ -104,14 +104,14 @@ class Peer(Base):
 
     @property
     def split_stake(self) -> float:
+        if self.yearly_message_count is None:
+            return 0
         if self.safe_balance is None:
             raise ValueError("Safe balance not set")
         if self.channel_balance is None:
             raise ValueError("Channel balance not set")
         if self.safe_address_count is None:
             raise ValueError("Safe address count not set")
-        if self.yearly_message_count is None:
-            return 0
 
         split_stake = float(self.safe_balance) / float(self.safe_address_count) + float(
             self.channel_balance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of `yearly_message_count` to ensure the method returns `0` immediately if it's not set, enhancing performance and preventing unnecessary calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->