### PR TITLE
Increase production memory nodes

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -17,3 +17,12 @@ ctdapp:
     NODE_ADDRESS_3: http://ctdapp-green-node-3:3001
     NODE_ADDRESS_4: http://ctdapp-green-node-4:3001
     NODE_ADDRESS_5: http://ctdapp-green-node-5:3001
+
+deployment:
+  resources: |
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 200m
+      memory: 2Gi


### PR DESCRIPTION
Production nodes are getting restarted because of an out of memory.
Issues in hoprd are created to solve this issue:
https://github.com/hoprnet/hoprnet/issues/6470
https://github.com/hoprnet/hoprnet/issues/5917

Meanwhile we will increase the memory resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new deployment configuration for the application, enhancing resource management with specified CPU and memory limits and requests.
  
- **Improvements**
	- Optimized performance and stability in production environments through better resource allocation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->