### PR TITLE
Increase inbox size on production to 16'384

### DIFF
--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -12,7 +12,7 @@ config: |
       allow_recursive: false
       strategies: []
   inbox:
-    capacity: 2048
+    capacity: 16384
 
 identityPool:
   funding:

--- a/helm/values-prod-green.yaml
+++ b/helm/values-prod-green.yaml
@@ -12,7 +12,7 @@ config: |
       allow_recursive: false
       strategies: []
   inbox:
-    capacity: 2048
+    capacity: 16384
 
 identityPool:
   funding:


### PR DESCRIPTION
CT distribute message constantly to every eligible peer with the same tag. Every 2 minutes, the inbox is emptied and the content of each message is analyzed to extract the relayer from the body.
When the ticket size decreases, the number of messages landing in the inbox between two inbox checks increases. As the inbox is a circular buffer, if it's full, old messages simply get removed, thus skewing the relayed message per peer count.

By increasing the inbox size, we avoid the above-mentioned issue, without increasing number of api calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased inbox capacity from 2048 to 16384, enhancing the ability to process larger volumes of messages or data.
  
- **Performance Improvements**
	- Adjustments made to improve scalability and performance of the application by accommodating more extensive workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->