### PR TITLE
Ensure distribution restarts for peer away for too long

### DIFF
--- a/ct-app/core/components/lockedvar.py
+++ b/ct-app/core/components/lockedvar.py
@@ -91,9 +91,11 @@ class LockedVar(Base):
     async def replace_value(self, old: Any, new: Any):
         """
         Asynchronously replace the old value with the new value in a locked manner. If the type of the value is different from the type of the variable, a TypeError will be raised.
+        Returns true if the value was replaced, false otherwise.
 
         :param old: The old value to replace.
         :param new: The new value to replace with.
+        :return: True if the value was replaced, false otherwise.
         """
         if self.type and not isinstance(new, self.type):
             self.warning(
@@ -103,6 +105,9 @@ class LockedVar(Base):
         async with self.lock:
             if self.value == old:
                 self.value = new
+                return True
+            else:
+                return False
 
     @property
     def log_prefix(self):

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -127,7 +127,6 @@ class Core(Base):
                 if peer in visible_peers:
                     if await peer.yearly_message_count.replace_value(None, 0):
                         # peer was already known, but distribution stopped for him because he was set in the `unreachable` state.
-                        peer.running = True
                         peer.start_async_processes()
                     counts["known"] += 1
 

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -125,8 +125,10 @@ class Core(Base):
             for peer in current_peers:
                 # if peer is still visible
                 if peer in visible_peers:
-                    await peer.yearly_message_count.replace_value(None, 0)
-                    peer.running = True
+                    if await peer.yearly_message_count.replace_value(None, 0):
+                        # peer was already known, but distribution stopped for him because he was set in the `unreachable` state.
+                        peer.running = True
+                        peer.start_async_processes()
                     counts["known"] += 1
 
                 # if peer is not visible anymore

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -10,7 +10,7 @@ backup:
 ctdapp:
   core:
     replicas: 1
-    tag: v3.4.0
+    tag: v3.4.1
   nodes:
     NODE_ADDRESS_1: http://ctdapp-green-node-1:3001
     NODE_ADDRESS_2: http://ctdapp-green-node-2:3001


### PR DESCRIPTION
If a peer is away for too long (could be because of a re-sync) --"too long" meaning longer than the delay between two triggers of the `connected_peers` method, set to 5min on prod--, distribution would stop for him and wouldn't restart after coming back online.
This was caused by a logic issue in the `connected_peers` method not re-starting the distribution process in this situation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the method for replacing values to return a boolean indicating the success of the operation.
	- Updated logic in the peer connection process to conditionally start processes based on the success of the value replacement.
	- Incremented the application version to v3.4.1 for improved deployment.

- **Bug Fixes**
	- Improved control flow to ensure processes are only initiated for peers that meet specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->