### PR TITLE
Upgrade nodes to 2.2

### DIFF
--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -12,8 +12,8 @@ ctdapp:
     replicas: 1
     tag: staging
   nodes:
-    NODE_ADDRESS_1: http://ctdapp-blue-node-1.ctdapp.svc:3001
-    NODE_ADDRESS_2: http://ctdapp-blue-node-2.ctdapp.svc:3001
-    NODE_ADDRESS_3: http://ctdapp-blue-node-3.ctdapp.svc:3001
-    NODE_ADDRESS_4: http://ctdapp-blue-node-4.ctdapp.svc:3001
-    NODE_ADDRESS_5: http://ctdapp-blue-node-5.ctdapp.svc:3001
+    NODE_ADDRESS_1: http://ctdapp-green-node-1.ctdapp.svc:3001
+    NODE_ADDRESS_2: http://ctdapp-green-node-2.ctdapp.svc:3001
+    NODE_ADDRESS_3: http://ctdapp-green-node-3.ctdapp.svc:3001
+    NODE_ADDRESS_4: http://ctdapp-green-node-4.ctdapp.svc:3001
+    NODE_ADDRESS_5: http://ctdapp-green-node-5.ctdapp.svc:3001


### PR DESCRIPTION
Change ctdapp-core to point to nodes using 2.2

@jeandemeusy  Before merge this PR it needs to be executed the script that opens the channels in the new green nodes, and closes the channels in the blue current nodes.