### PR TITLE
Scale down saint-louis in staging

### DIFF
--- a/helm/values-staging-blue.yaml
+++ b/helm/values-staging-blue.yaml
@@ -1,4 +1,4 @@
-replicas: 5
+replicas: 0
 network: rotsee
 version: saint-louis
 


### PR DESCRIPTION
Remove staging blue nodes using saint-louis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Deployment of replicas has been temporarily disabled for staging environments.
  
- **Bug Fixes**
	- No changes made to existing configurations; all settings remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->