### PR TITLE
Fix open channel API body

### DIFF
--- a/ct-app/core/components/hoprd_api.py
+++ b/ct-app/core/components/hoprd_api.py
@@ -95,7 +95,7 @@ class HoprdAPI(Base):
         """
         data = {
             "amount": amount,
-            "destination": peer_address,
+            "peerAddress": peer_address,
         }
 
         is_ok, response = await self.__call_api(


### PR DESCRIPTION
Instead of passing `peerAddress`, `destination` was provided, which lead into channels not being opened.
10 peers were expecting to have channels open from CT, which is now fixed already.