### PR TITLE
Not convert peer_id to lowercase

### DIFF
--- a/ct-app/core/components/address.py
+++ b/ct-app/core/components/address.py
@@ -9,7 +9,7 @@ class Address:
         :param id: The id of the peer.
         :param address: The address of the peer.
         """
-        self.hopr = hopr.lower() if isinstance(hopr, str) else hopr
+        self.hopr = hopr
         self.native = native.lower() if isinstance(native, str) else native
 
     def __eq__(self, other):

--- a/ct-app/core/subgraph/entries/topology.py
+++ b/ct-app/core/subgraph/entries/topology.py
@@ -13,7 +13,7 @@ class Topology(SubgraphEntry):
         :param address: The peer's native address.
         :param channels_balance: The peer's outgoing channels total balance.
         """
-        self.peer_id: str = peer_id.lower() if isinstance(peer_id, str) else peer_id
+        self.peer_id: str = peer_id
         self.address = address.lower() if isinstance(address, str) else address
         self.channels_balance = channels_balance
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated handling of `hopr` and `peer_id` parameters to preserve original casing in Address and Topology classes.

The changes ensure more precise string handling during object initialization, which may impact how these objects are compared or processed in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->