### PR TITLE
Fix closing old channels

### DIFF
--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -281,7 +281,7 @@ class Node(Base):
         peers = {p for p in peers if not p.is_old(self.params.peer.minVersion)}
 
         addresses_w_timestamp = {
-            p.address.hopr: datetime.now() for p in peers}
+            p.address.native: datetime.now() for p in peers}
 
         await self.peers.set(peers)
         await self.peer_history.update(addresses_w_timestamp)

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -10,7 +10,7 @@ backup:
 ctdapp:
   core:
     replicas: 1
-    tag: v3.6.0
+    tag: v3.6.1
 
   nodes:
     NODE_ADDRESS_1: http://ctdapp-blue-node-1:3001


### PR DESCRIPTION
A dictionary of addresses and timestamp is populated/updated when a peer is last seen. If this timestamp exceeds a given duration (set in the config file), then the channel to this address will be automatically closed.

However, it was populated with peer_id instead of addresses. Thus when looping through it to find the addresses that were not seen for a while, each entry of the dictionary would eventually be considered as too old, and it's outgoing channel would be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated peer address retrieval mechanism to use native address format instead of HOPR address format.
  
- **New Features**
	- Upgraded the core application version from v3.6.0 to v3.6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->