### PR TITLE
Clean dependancies and update `aiohttp`

### DIFF
--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,5 +1,5 @@
 # HTTP requests
-aiohttp==3.8.4
+aiohttp>=3.10.11
 
 # Import .yaml files
 pyYAML>=6.0.1

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -1,13 +1,8 @@
 # HTTP requests
 aiohttp>=3.10.11
 
-# Import .yaml files
+# Support of .yaml files
 pyYAML>=6.0.1
-
-
-# Database connection libraries
-sqlalchemy==2.0.20
-psycopg2-binary==2.9.9
 
 # Metrics
 prometheus_client==0.17.1


### PR DESCRIPTION
Remove db dependancies and update `aiohttp` lib following GH insights on dependancies https://github.com/hoprnet/ct-research/network/dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `aiohttp` library to a minimum version of 3.10.11
	- Updated comment for `pyYAML` library
	- Removed database connection libraries (`sqlalchemy` and `psycopg2-binary`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->