### PR TITLE
Temporarily stop using blue node 1

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -13,7 +13,7 @@ ctdapp:
     tag: v3.7.0
 
   nodes:
-    NODE_ADDRESS_1: http://ctdapp-blue-node-1:3001
+    # NODE_ADDRESS_1: http://ctdapp-blue-node-1:3001
     NODE_ADDRESS_2: http://ctdapp-blue-node-2:3001
     NODE_ADDRESS_3: http://ctdapp-blue-node-3:3001
     NODE_ADDRESS_4: http://ctdapp-blue-node-4:3001


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Disabled `NODE_ADDRESS_1` in production configuration
	- Other node addresses remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->