### PR TITLE
Add env var: HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS

### DIFF
--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -10,6 +10,8 @@ deployment:
       value: full
     - name: HOPRD_LOG_FORMAT
       value: json
+    - name: HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS
+      value: "10000"
 
 config: |
   hopr:

--- a/helm/values-staging-blue.yaml
+++ b/helm/values-staging-blue.yaml
@@ -2,6 +2,17 @@ replicas: 0
 network: rotsee
 version: singapore-latest
 
+deployment:
+  env: |
+    - name: RUST_LOG
+      value: info
+    - name: RUST_BACKTRACE
+      value: full
+    - name: HOPRD_LOG_FORMAT
+      value: json
+    - name: HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS
+      value: "10000"
+
 config: |
   hopr:
     chain:

--- a/helm/values-staging-green.yaml
+++ b/helm/values-staging-green.yaml
@@ -10,6 +10,8 @@ deployment:
       value: full
     - name: HOPRD_LOG_FORMAT
       value: json
+    - name: HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS
+      value: "10000"
 
 config: |
   hopr:


### PR DESCRIPTION
Setting this env var to a higher value to ensure stream counts are not an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added new environment variable `HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS` with value "10000" across production and staging environments
	- Updated deployment configurations for blue and green environments with logging and performance-related settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->