### PR TITLE
Fix out of memory issue

### DIFF
--- a/ct-app/core/components/asyncloop.py
+++ b/ct-app/core/components/asyncloop.py
@@ -31,7 +31,7 @@ class AsyncLoop(Base, metaclass=Singleton):
             cls().add(task)
 
     @classmethod
-    def add(cls, callback: Callable,  *args, publish_to_task_set: bool = True):
+    def add(cls, callback: Callable, *args, publish_to_task_set: bool = True):
         try:
             task = asyncio.ensure_future(callback(*args))
         except Exception as e:

--- a/ct-app/core/components/asyncloop.py
+++ b/ct-app/core/components/asyncloop.py
@@ -31,7 +31,7 @@ class AsyncLoop(Base, metaclass=Singleton):
             cls().add(task)
 
     @classmethod
-    def add(cls, callback: Callable, publish_to_task_set: bool = True, *args):
+    def add(cls, callback: Callable,  *args, publish_to_task_set: bool = True):
         try:
             task = asyncio.ensure_future(callback(*args))
         except Exception as e:

--- a/ct-app/core/components/asyncloop.py
+++ b/ct-app/core/components/asyncloop.py
@@ -31,14 +31,15 @@ class AsyncLoop(Base, metaclass=Singleton):
             cls().add(task)
 
     @classmethod
-    def add(cls, callback: Callable, *args):
+    def add(cls, callback: Callable, publish_to_task_set: bool = True, *args):
         try:
             task = asyncio.ensure_future(callback(*args))
         except Exception as e:
             cls().error(f"Failed to create task for {callback.__name__}: {e}")
             return
             
-        cls().tasks.add(task)
+        if publish_to_task_set:
+            cls().tasks.add(task)
 
     @classmethod
     async def gather(cls):

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -343,7 +343,8 @@ class Node(Base):
         if message.relayer not in channels:
             return
 
-        AsyncLoop.add(self.api.send_message, self.address.hopr, message.format(), [message.relayer])
+        AsyncLoop.add(self.api.send_message, self.address.hopr, message.format(), [
+                      message.relayer], publish_to_task_set=False)
         MESSAGES_STATS.labels("sent", self.address.hopr, message.relayer).inc()
 
     async def tasks(self):

--- a/ct-app/core/node.py
+++ b/ct-app/core/node.py
@@ -136,7 +136,7 @@ class Node(Base):
 
         for address in addresses_without_channels:
             AsyncLoop.add(NodeHelper.open_channel, self.address, self.api, address,
-                          self.params.channel.fundingAmount)
+                          self.params.channel.fundingAmount, publish_to_task_set=False)
 
     @master(flagguard, formalin, connectguard)
     async def close_incoming_channels(self):
@@ -150,7 +150,7 @@ class Node(Base):
 
         for channel in in_opens:
             AsyncLoop.add(NodeHelper.close_incoming_channel,
-                          self.address, self.api, channel)
+                          self.address, self.api, channel, publish_to_task_set=False)
 
     @master(flagguard, formalin, connectguard)
     async def close_pending_channels(self):
@@ -167,7 +167,7 @@ class Node(Base):
 
         for channel in out_pendings:
             AsyncLoop.add(NodeHelper.close_pending_channel,
-                          self.address, self.api, channel)
+                          self.address, self.api, channel, publish_to_task_set=False)
 
     @master(flagguard, formalin, connectguard)
     async def close_old_channels(self):
@@ -208,7 +208,7 @@ class Node(Base):
         self.info(f"Closing {len(channels_to_close)} old channels")
         for channel in channels_to_close:
             AsyncLoop.add(NodeHelper.close_old_channel,
-                          self.address, self.api, channel)
+                          self.address, self.api, channel, publish_to_task_set=False)
 
     @master(flagguard, formalin, connectguard)
     async def fund_channels(self):
@@ -233,7 +233,7 @@ class Node(Base):
         for channel in low_balances:
             if channel.destination_peer_id in peer_ids:
                 AsyncLoop.add(NodeHelper.fund_channel, self.address,
-                              self.api, channel, self.params.channel.fundingAmount)
+                              self.api, channel, self.params.channel.fundingAmount, publish_to_task_set=False)
 
     @master(flagguard, formalin, connectguard)
     async def retrieve_peers(self):

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -10,7 +10,7 @@ backup:
 ctdapp:
   core:
     replicas: 1
-    tag: v3.7.0
+    tag: v3.7.1
 
   nodes:
     NODE_ADDRESS_1: http://ctdapp-blue-node-1:3001


### PR DESCRIPTION
The PR #602 introduced an undesired behavior: memory consumption in increase ever since it's been merged. 

The issue is that the async task of calling the `send_message` API endpoint was changed from being wrapped by `asyncio.create_task` to being wrapped to the custom `AsyncLoop.add` method. This method adds each task to a list of tasks, without ever getting them out of it, thus resulting in a ever-growing list which eventually lead to an OOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added optional control for task management in the asynchronous loop.
  - Modified task publishing behavior in message queue observation methods.

- **Chores**
  - Updated Helm chart version from v3.7.0 to v3.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->