### PR TITLE
Revert "hoprd: Test Quic on blue prod nodes (#618)"

### DIFF
--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -1,9 +1,6 @@
 replicas: 5
 network: dufour
-# testing Quic changes already applied to v2.2.2 branch
-# see https://console.cloud.google.com/artifacts/docker/hoprassociation/europe-west3/docker-images/hoprd/sha256:90cf0ca8d87a92a7e43887f9d9805864090616eba114295b342bdedfee80b110?inv=1&invt=AbokDA&project=hoprassociation
-version: "2.2.2-commit.fb8c1711"
-# version: "2.2.1"
+version: "2.2.1"
 
 deployment:
   env: |


### PR DESCRIPTION
This reverts commit 2941ca8a0cbafa724c1d2da4e7b3efe2c534fd06.

Reverts the QUIC introduction.