### PR TITLE
Update nodes to use load balancer

### DIFF
--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -36,7 +36,7 @@ releases:
   namespace: ctdapp
   chart: hoprassociation/cluster-hoprd
   condition: blue-nodes.enabled
-  version: 0.3.1
+  version: 0.3.4
   wait: true
   timeout: 5
   values:

--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -49,7 +49,7 @@ releases:
   namespace: ctdapp
   chart: hoprassociation/cluster-hoprd
   condition: green-nodes.enabled
-  version: 0.3.1
+  version: 0.3.4
   wait: true
   timeout: 5
   values:

--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -1,6 +1,6 @@
 replicas: 5
 network: dufour
-version: "singapore-latest"
+version: singapore-latest
 
 service:
   type: LoadBalancer

--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -1,6 +1,9 @@
 replicas: 5
 network: dufour
-version: "2.2.1"
+version: "singapore-latest"
+
+service:
+  type: LoadBalancer
 
 deployment:
   env: |

--- a/helm/values-prod-green.yaml
+++ b/helm/values-prod-green.yaml
@@ -1,4 +1,4 @@
-replicas: 5
+replicas: 0
 network: dufour
 version: singapore-latest
 

--- a/helm/values-prod-green.yaml
+++ b/helm/values-prod-green.yaml
@@ -1,6 +1,9 @@
 replicas: 5
 network: dufour
-version: "2.1.2"
+version: singapore-latest
+
+service:
+  type: LoadBalancer
 
 config: |
   hopr:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -13,11 +13,11 @@ ctdapp:
     tag: v3.7.3
 
   nodes:
-    NODE_ADDRESS_1: http://ctdapp-blue-node-1:3001
-    NODE_ADDRESS_2: http://ctdapp-blue-node-2:3001
-    NODE_ADDRESS_3: http://ctdapp-blue-node-3:3001
-    NODE_ADDRESS_4: http://ctdapp-blue-node-4:3001
-    NODE_ADDRESS_5: http://ctdapp-blue-node-5:3001
+    NODE_ADDRESS_1: http://ctdapp-blue-node-1-p2p-tcp:3001
+    NODE_ADDRESS_2: http://ctdapp-blue-node-2-p2p-tcp:3001
+    NODE_ADDRESS_3: http://ctdapp-blue-node-3-p2p-tcp:3001
+    NODE_ADDRESS_4: http://ctdapp-blue-node-4-p2p-tcp:3001
+    NODE_ADDRESS_5: http://ctdapp-blue-node-5-p2p-tcp:3001
 
 deployment:
   resources: |

--- a/helm/values-staging-blue.yaml
+++ b/helm/values-staging-blue.yaml
@@ -2,6 +2,9 @@ replicas: 0
 network: rotsee
 version: singapore-latest
 
+service:
+  type: LoadBalancer
+
 deployment:
   env: |
     - name: RUST_LOG

--- a/helm/values-staging-green.yaml
+++ b/helm/values-staging-green.yaml
@@ -1,6 +1,9 @@
 replicas: 5
 network: rotsee
-version: "2.2.2-commit.fb8c1711"
+version: singapore-latest
+
+service:
+  type: LoadBalancer
 
 deployment:
   env: |

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -12,8 +12,8 @@ ctdapp:
     replicas: 1
     tag: staging
   nodes:
-    NODE_ADDRESS_1: http://ctdapp-green-node-1.ctdapp.svc:3001
-    NODE_ADDRESS_2: http://ctdapp-green-node-2.ctdapp.svc:3001
-    NODE_ADDRESS_3: http://ctdapp-green-node-3.ctdapp.svc:3001
-    NODE_ADDRESS_4: http://ctdapp-green-node-4.ctdapp.svc:3001
-    NODE_ADDRESS_5: http://ctdapp-green-node-5.ctdapp.svc:3001
+    NODE_ADDRESS_1: http://ctdapp-green-node-1-p2p-tcp.ctdapp.svc:3001
+    NODE_ADDRESS_2: http://ctdapp-green-node-2-p2p-tcp.ctdapp.svc:3001
+    NODE_ADDRESS_3: http://ctdapp-green-node-3-p2p-tcp.ctdapp.svc:3001
+    NODE_ADDRESS_4: http://ctdapp-green-node-4-p2p-tcp.ctdapp.svc:3001
+    NODE_ADDRESS_5: http://ctdapp-green-node-5-p2p-tcp.ctdapp.svc:3001


### PR DESCRIPTION
Change the service type of hoprd nodes to use LoadBalancer L4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled external service exposure via load balancers for production and staging environments.

- **Chores**
  - Updated release versions across deployments for consistency.
  - Revised node endpoint URLs to adopt new connection protocols.
  - Adjusted the replica count in one production configuration for optimized resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->