### PR TITLE
Bump all HOPRd nodes to 2.2.2

### DIFF
--- a/helm/values-prod-blue.yaml
+++ b/helm/values-prod-blue.yaml
@@ -1,6 +1,6 @@
 replicas: 5
 network: dufour
-version: singapore-latest
+version: "2.2.2"
 
 service:
   type: LoadBalancer

--- a/helm/values-prod-green.yaml
+++ b/helm/values-prod-green.yaml
@@ -1,6 +1,6 @@
 replicas: 0
 network: dufour
-version: singapore-latest
+version: "2.2.2"
 
 service:
   type: LoadBalancer

--- a/helm/values-staging-blue.yaml
+++ b/helm/values-staging-blue.yaml
@@ -1,6 +1,6 @@
 replicas: 0
 network: rotsee
-version: singapore-latest
+version: "2.2.2"
 
 service:
   type: LoadBalancer

--- a/helm/values-staging-green.yaml
+++ b/helm/values-staging-green.yaml
@@ -1,6 +1,6 @@
 replicas: 5
 network: rotsee
-version: singapore-latest
+version: "2.2.2"
 
 service:
   type: LoadBalancer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
   - Updated deployment configurations by replacing a dynamic version tag with a fixed version ("2.2.2") across both production and staging environments to ensure consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->