### PR TITLE
Remove ETH addresses checksum-ing

### DIFF
--- a/ct-app/core/api/response_objects.py
+++ b/ct-app/core/api/response_objects.py
@@ -22,6 +22,10 @@ def _convert(value: Any):
 
     return value
 
+def try_to_lower(value: Any):
+    if isinstance(value, str):
+        return value.lower()
+    return value
 
 class ApiResponseObject:
     def __init__(self, data: dict):
@@ -75,10 +79,16 @@ class Balances(ApiResponseObject):
 class Infos(ApiResponseObject):
     keys = {"hopr_node_safe": "hoprNodeSafe"}
 
+    def post_init(self):
+        self.hopr_node_safe = try_to_lower(self.hopr_node_safe)
+
 
 class ConnectedPeer(ApiResponseObject):
     keys = {"address": "peerAddress",
             "peer_id": "peerId", "version": "reportedVersion"}
+
+    def post_init(self):
+        self.address = try_to_lower(self.address)
 
 
 class Channel(ApiResponseObject):
@@ -94,10 +104,9 @@ class Channel(ApiResponseObject):
 
     def post_init(self):
         self.status = ChannelStatus.fromString(self.status)
-        if isinstance(self.destination_address, str):
-            self.destination_address = self.destination_address.lower()
-        if isinstance(self.source_address, str):
-            self.source_address = self.source_address.lower()
+        
+        self.destination_address = try_to_lower(self.destination_address)
+        self.source_address = try_to_lower(self.source_address)
         
 
 class TicketPrice(ApiResponseObject):

--- a/ct-app/core/api/response_objects.py
+++ b/ct-app/core/api/response_objects.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from core.components.utils import Utils
-
 from .channelstatus import ChannelStatus
 
 
@@ -97,9 +95,9 @@ class Channel(ApiResponseObject):
     def post_init(self):
         self.status = ChannelStatus.fromString(self.status)
         if isinstance(self.destination_address, str):
-            self.destination_address = Utils.checksum_address(self.destination_address)
+            self.destination_address = self.destination_address.lower()
         if isinstance(self.source_address, str):
-            self.source_address = Utils.checksum_address(self.source_address)
+            self.source_address = self.source_address.lower()
         
 
 class TicketPrice(ApiResponseObject):

--- a/ct-app/core/components/address.py
+++ b/ct-app/core/components/address.py
@@ -1,7 +1,5 @@
 from prometheus_client import Gauge
 
-from core.components.utils import Utils
-
 PEER = Gauge("ct_address_pairs", "PeerID / address pairs of node reachable by CT", ["peer_id", "address"])
 
 class Address:
@@ -16,7 +14,7 @@ class Address:
         :param address: The address of the peer.
         """
         self.hopr = hopr
-        self.native = Utils.checksum_address(native)
+        self.native = native.lower() if native is not None else None
         PEER.labels(self.hopr, self.native).set(1)
 
     def __eq__(self, other):

--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -1,4 +1,3 @@
-from web3 import Web3
 
 from core.baseclass import Base
 from core.subgraph.entries import Safe
@@ -152,21 +151,3 @@ class Utils(Base):
                 c.balance) / 1e18
 
         return results
-
-    @classmethod
-    def checksum_address(cls, address: str):
-        if not cls._web3:
-            cls._web3 = Web3()
-
-        cls().info(f"Checksumming address {address}")
-        try:
-            checksummed = cls._web3.to_checksum_address(address)
-            cls().info(f"Checksummed address {address} => {checksummed}")
-            return checksummed
-        except ValueError:
-            pass
-        except TypeError:
-            pass
-
-        cls().error(f"Not using a checksummed address due to failure, using {address}")
-        return address

--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -6,8 +6,6 @@ from .environment_utils import EnvironmentUtils
 
 
 class Utils(Base):
-    _web3 = None  # Class variable to store Web3 instance
-
     @classmethod
     def nodesCredentials(
         cls, address_prefix: str, keyenv: str

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -216,7 +216,7 @@ class Core(Base):
             for account in await self.providers[Type.MAINNET_BALANCES].get(
                 id_in=list(balances.keys())
             ):
-                balances[Utils.checksum_address(account["id"])] += float(account["totalBalance"]) / 1e18
+                balances[account["id"].lower()] += float(account["totalBalance"]) / 1e18
         except ProviderError as err:
             self.error(f"eoa_balances: {err}")
 
@@ -224,7 +224,7 @@ class Core(Base):
             for account in await self.providers[Type.GNOSIS_BALANCES].get(
                 id_in=list(balances.keys())
             ):
-                balances[Utils.checksum_address(account["id"])] += float(account["totalBalance"]) / 1e18
+                balances[account["id"].lower()] += float(account["totalBalance"]) / 1e18
         except ProviderError as err:
             self.error(f"eoa_balances: {err}")
 

--- a/ct-app/core/subgraph/entries/account.py
+++ b/ct-app/core/subgraph/entries/account.py
@@ -13,7 +13,7 @@ class Account(SubgraphEntry):
         :param redeemed_value: The value of redemeed tickets.
         """
 
-        self.address = self.checksum(address)
+        self.address = address.lower() if address is not None else None
         self.redeemed_value = float(redeemed_value)
 
 

--- a/ct-app/core/subgraph/entries/allocation.py
+++ b/ct-app/core/subgraph/entries/allocation.py
@@ -4,7 +4,7 @@ from .safe import Safe
 
 class Allocation(SubgraphEntry):
     def __init__(self, id: str, claimedAmount: str, allocatedAmount: str):
-        self.address = self.checksum(id)
+        self.address = id.lower() if id is not None else None
         self.claimed_amount = float(claimedAmount) / 1e18
         self.allocated_amount = float(allocatedAmount) / 1e18
         self.linked_safes: set[Safe] = set()

--- a/ct-app/core/subgraph/entries/balance.py
+++ b/ct-app/core/subgraph/entries/balance.py
@@ -13,7 +13,7 @@ class Balance(SubgraphEntry):
         :param address: The address of the EOA.
         :param balance: The balance of the EOA.
         """
-        self.address = self.checksum(address)
+        self.address = address.lower() if address is not None else None
         self.balance = float(balance) if balance else 0
         self.linked_safes: set[Safe] = set()
 

--- a/ct-app/core/subgraph/entries/entry.py
+++ b/ct-app/core/subgraph/entries/entry.py
@@ -1,5 +1,3 @@
-from web3 import Web3
-
 import logging
 
 logging.basicConfig()
@@ -8,15 +6,6 @@ formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
 
 
 class SubgraphEntry:
-    _web3 = None  # Class variable to store Web3 instance
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-
-    logger = logging.getLogger("ct-app:subgraph")
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
-    logger.propagate = False
-
     def __str__(self):
         cls = self.__class__.__name__
         fields = ", ".join(f"{field}={value}" for field, value in vars(self).items())
@@ -28,21 +17,3 @@ class SubgraphEntry:
 
     def __eq__(self, other):
         return vars(self) == vars(other)
-
-    @classmethod
-    def checksum(cls, address: str):
-        if not cls._web3:
-            cls._web3 = Web3()
-    
-        cls.logger.info(f"subgraph: Checksumming address {address}")
-        try:
-            checksummed = cls._web3.to_checksum_address(address)
-            cls.logger.info(f"subgraph: Checksummed address {address} => {checksummed}")
-            return checksummed
-        except ValueError:
-            pass
-        except TypeError:
-            pass
-
-        cls.logger.error(f"subgraph: Not using a checksummed address due to failure, using {address}")
-        return address

--- a/ct-app/core/subgraph/entries/node.py
+++ b/ct-app/core/subgraph/entries/node.py
@@ -14,7 +14,7 @@ class Node(SubgraphEntry):
         :param safe: A Safe object.
         """
 
-        self.address = self.checksum(address)
+        self.address = address.lower() if address is not None else None
         self.safe = safe
 
     @classmethod

--- a/ct-app/core/subgraph/entries/safe.py
+++ b/ct-app/core/subgraph/entries/safe.py
@@ -14,10 +14,10 @@ class Safe(SubgraphEntry):
         :param balance: The balance of the safe.
         :param allowance: The allowance of the safe.
         """
-        self.address = self.checksum(address)
+        self.address = address.lower() if address is not None else None
         self.balance = float(balance) if balance else 0
         self.allowance = float(allowance) if allowance else 0
-        self.owners = [self.checksum(owner) for owner in owners ] 
+        self.owners = [owner.lower() for owner in owners if owner is not None]
         self.additional_balance = 0
 
     @property

--- a/ct-app/core/subgraph/entries/topology.py
+++ b/ct-app/core/subgraph/entries/topology.py
@@ -14,7 +14,7 @@ class Topology(SubgraphEntry):
         :param channels_balance: The peer's outgoing channels total balance.
         """
         self.peer_id: str = peer_id
-        self.address = self.checksum(address)
+        self.address = address.lower() if address is not None else None
         self.channels_balance = channels_balance
 
     @classmethod

--- a/ct-app/requirements.txt
+++ b/ct-app/requirements.txt
@@ -4,9 +4,6 @@ aiohttp>=3.10.11
 # Support of .yaml files
 pyYAML>=6.0.1
 
-# Checksum ETH addresses
-web3==7.8.0
-
 # Metrics
 prometheus_client==0.17.1
 

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -11,7 +11,7 @@ ctdapp:
   core:
     replicas: 1
     # see https://console.cloud.google.com/artifacts/docker/hoprassociation/europe-west3/docker-images/cover-traffic?inv=1&invt=AbpZVw&project=hoprassociation
-    tag: v3.7.4
+    tag: v3.8.1
 
   nodes:
     NODE_ADDRESS_1: http://ctdapp-blue-node-1-p2p-tcp:3001


### PR DESCRIPTION
Checksuming addresses wasn't needed for the logic, but rather for a UX improvement using Grafana, where a user could use his standard (checksumed) safe address in the filter bars.
However, this conversion had rather a negative impact on CT. Safe addresses and node addresses where checksumed and compared between them at multiple places. If one checksum operation failed, those comparison would obviously fail too, ending in the given node being not eligible. Getting rid of it implies that the UX in Grafana will be *slightly* worse, but anyway worth doing it to not impact distribution for too long.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Address handling has been standardized so that all addresses are now consistently presented in lowercase for improved clarity and uniformity.
- **Chores**
  - Removed an unnecessary external dependency, streamlining internal processing without affecting visible functionality.
- **Updates**
  - Upgraded the core application version to v3.8.1, ensuring access to the latest features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->