### PR TITLE
Increase minimum version to receive CT to `2.2.1`

### DIFF
--- a/ct-app/.configs/core_prod_config.yaml
+++ b/ct-app/.configs/core_prod_config.yaml
@@ -89,7 +89,7 @@ economicModel:
 # 
 # =============================================================================
 peer:
-  minVersion: '2.1.5'
+  minVersion: '2.2.1'
   initialSleep:
     mean: 30
     std: 2

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -11,7 +11,7 @@ ctdapp:
   core:
     replicas: 1
     # see https://console.cloud.google.com/artifacts/docker/hoprassociation/europe-west3/docker-images/cover-traffic?inv=1&invt=AbpZVw&project=hoprassociation
-    tag: v3.8.1
+    tag: v3.8.2
 
   nodes:
     NODE_ADDRESS_1: http://ctdapp-blue-node-1-p2p-tcp:3001


### PR DESCRIPTION
Until now CT was expecting peers on version less or equal than 2.2.1 to relay messages. However, since CT uses a different ticket price than what the oracle dictate, the version <2.2.1 will refuse to relay messages.
This PR enforces CT to send messages only to peers on >=2.2.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Raised the minimum supported version for a peer component to maintain alignment.
  - Incremented the core application’s version tag to reflect the latest release updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->