### PR TITLE
Expose balance multiplier (2.3)

### DIFF
--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -17,6 +17,7 @@ from .subgraph import URL, Type, entries
 # endregion
 
 # region Metrics
+BALANCE_MULTIPLIER = Gauge("ct_balance_multiplier", "factor to multiply the balance by")
 ELIGIBLE_PEERS = Gauge("ct_eligible_peers", "# of eligible peers for rewards")
 MESSAGE_COUNT = Gauge(
     "ct_message_count", "messages one should receive / year", ["peer_id", "model"]
@@ -67,6 +68,8 @@ class Core:
         }
 
         self.running = True
+
+        BALANCE_MULTIPLIER.set(1e18)
 
     @property
     def api(self) -> HoprdAPI:


### PR DESCRIPTION
All balances on the 2.3 compliant CT version are in wei. Thus, in the dashboard, for readability, balances are divided by 1e18.
However, in the 3.0 compliant CT version, all balances are in wxHOPR. In the dashboards, dividing currencies by 1e18 wouldn't make sense anymore. 

The added metric allows to dynamically do the conversion.
It will be removed once a single CT instance will run, for 3.0 nodes. 

Twin PR for 3.0: #679 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Prometheus metric to monitor the balance multiplier value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->