### PR TITLE
Expose balance multiplier (3.0)

### DIFF
--- a/ct-app/core/api/hoprd_api.py
+++ b/ct-app/core/api/hoprd_api.py
@@ -244,7 +244,6 @@ class HoprdAPI:
         is_ok, resp = await self.__call_api(HTTPMethod.GET, "network/price")
         return response.TicketPrice(resp) if is_ok else None
 
-
     async def get_sessions(self, protocol: Protocol = Protocol.UDP) -> list[response.Session]:
         """
         Lists existing Session listeners for the given IP protocol

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -19,6 +19,7 @@ from .subgraph import URL, Type, entries
 # endregion
 
 # region Metrics
+BALANCE_MULTIPLIER = Gauge("balance_multiplier", "factor to multiply the balance by")
 ELIGIBLE_PEERS = Gauge("ct_eligible_peers", "# of eligible peers for rewards")
 MESSAGE_COUNT = Gauge(
     "ct_message_count", "messages one should receive / year", ["address", "model"]
@@ -69,6 +70,8 @@ class Core:
         }
 
         self.running = True
+
+        BALANCE_MULTIPLIER.set(1)
 
     @property
     def api(self) -> HoprdAPI:

--- a/ct-app/core/core.py
+++ b/ct-app/core/core.py
@@ -19,7 +19,7 @@ from .subgraph import URL, Type, entries
 # endregion
 
 # region Metrics
-BALANCE_MULTIPLIER = Gauge("balance_multiplier", "factor to multiply the balance by")
+BALANCE_MULTIPLIER = Gauge("ct_balance_multiplier", "factor to multiply the balance by")
 ELIGIBLE_PEERS = Gauge("ct_eligible_peers", "# of eligible peers for rewards")
 MESSAGE_COUNT = Gauge(
     "ct_message_count", "messages one should receive / year", ["address", "model"]


### PR DESCRIPTION
All balances on the 2.3 compliant CT version are in wei. Thus, in the dashboard, for readability, balances are divided by 1e18.
However, in the 3.0 compliant CT version, all balances are in wxHOPR. In the dashboards, dividing currencies by 1e18 wouldn't make sense anymore. 
The added metric allows to dynamically do the conversion.
It will be removed once a single CT instance will run, for 3.0 nodes. 

Twin PR for 2.3: #678 