### PR TITLE
refactor: remove unused imports and default method

### DIFF
--- a/ct-app/core/components/utils.py
+++ b/ct-app/core/components/utils.py
@@ -1,4 +1,4 @@
-from core.subgraph.entries import Safe
+from copy import deepcopy
 
 from .environment_utils import EnvironmentUtils
 
@@ -42,7 +42,10 @@ class Utils:
             topo = next(filter(lambda t: filter_func(t, peer), topology), None)
             node = next(filter(lambda n: filter_func(n, peer), nodes), None)
 
-            peer.safe = getattr(node, "safe", Safe.default())
+            if node is None or not hasattr(node, "safe"):
+                continue
+
+            peer.safe = deepcopy(node.safe)
 
             peer.safe.additional_balance = 0
 
@@ -122,4 +125,5 @@ class Utils:
 
             results[c.source_peer_id]["channels_balance"] += int(c.balance) / 1e18
 
+        return results
         return results

--- a/ct-app/core/subgraph/entries/safe.py
+++ b/ct-app/core/subgraph/entries/safe.py
@@ -1,5 +1,3 @@
-import random
-
 from .entry import SubgraphEntry
 
 
@@ -39,13 +37,3 @@ class Safe(SubgraphEntry):
             safe["allowance"]["wxHoprAllowance"],
             [owner["owner"]["id"] for owner in safe["owners"]],
         )
-
-    @classmethod
-    def default(cls):
-        """
-        Create a new Safe with default values.
-        """
-        address = "1x" + "".join(
-            [str(hex(random.randint(0, 15)))[2] for _ in range(40)]
-        )
-        return cls(address, "1", "0", [])


### PR DESCRIPTION
To be able to run CT on staging, a random safe address was used in case none were found. This lead into having random safe addresses exposed to prometheus. 

It shouldn't have been there in the first place, eventhough was helpful. Now it's not needed anymore for sure, furthermore removing it helps no filling up the prometheus db