### PR TITLE
fix: Allow the close release pipeline to bump version using hopr bot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,3 +74,4 @@ jobs:
           zulip_topic: "Releases"
           gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
           attach_binaries: "false"
+          github_token: ${{ secrets.GH_RUNNER_TOKEN }}

--- a/ct-app/pyproject.toml
+++ b/ct-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ct-app"
-version = "3.14.3"
+version = "3.14.4"
 requires-python = ">=3.12"
 dependencies = ["core"]
 


### PR DESCRIPTION
The close release workflow is using the permissions of the invoker to bump the version in `main` branch directly. It needs to use the Hopr bot token which has an exclusion to do commits directly in `main` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped package version to 3.14.4
  * Updated release workflow configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->