### PR TITLE
fix(ci): restrict merge pipeline to default/protected branches

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -5,6 +5,8 @@ on:
     types:
       - closed
       # - synchronize
+    branches:
+      - main
 concurrency:
   group: merge-${{ github.event.pull_request.base.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Add `branches` filter to the merge workflow `pull_request` trigger to prevent it from running on PR-to-PR merges
- The workflow was triggering on all closed+merged PRs, including merges into non-default branches, wasting CI resources