### PR TITLE
feat(ci): migrate workflows to Workload Identity Provider auth

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -16,7 +16,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -16,7 +16,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     permissions:
       contents: read
       pull-requests: write
@@ -39,7 +39,6 @@ jobs:
       deployment_label_selector: "hoprds.hoprnet.org/cluster=${{ vars.CTDAPP_STAGING_DEPLOYMENT_CLUSTER }}"
       fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   notify:
     name: Notify failure

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -16,7 +16,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5b0f0e6c7e3a02e30a33b9f5150fb5b118676e58 # 0.11.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
 
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
 
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     permissions:
       contents: read
       pull-requests: write
@@ -111,7 +111,6 @@ jobs:
       deployment_label_selector: "hoprds.hoprnet.org/cluster=${{ vars.CTDAPP_STAGING_DEPLOYMENT_CLUSTER }}"
       fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   checks:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
 
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5b0f0e6c7e3a02e30a33b9f5150fb5b118676e58 # 0.11.0
     permissions:
       contents: read
       pull-requests: write
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        uses: hoprnet/hopr-workflows/actions/setup-nix@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
         with:
           cachix_cache_name: ct-dapp
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     permissions:
       contents: read
       pull-requests: write
@@ -42,10 +42,7 @@ jobs:
       docker_image_name: cover-traffic
       fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
   release:
     name: Close release
     needs:
@@ -53,9 +50,10 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1
         with:
           source_branch: ${{ github.ref_name }}
           file: ct-app/pyproject.toml
@@ -66,5 +64,4 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: HOPRd
           zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
     permissions:
       contents: read
       pull-requests: write
@@ -53,7 +53,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
         with:
           source_branch: ${{ github.ref_name }}
           file: ct-app/pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5b0f0e6c7e3a02e30a33b9f5150fb5b118676e58 # 0.11.0
     permissions:
       contents: read
       pull-requests: write
@@ -53,7 +53,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+        uses: hoprnet/hopr-workflows/actions/release-version@5b0f0e6c7e3a02e30a33b9f5150fb5b118676e58 # 0.11.0
         with:
           source_branch: ${{ github.ref_name }}
           file: ct-app/pyproject.toml

--- a/ct-app/flake.lock
+++ b/ct-app/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761373498,
-        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {

--- a/ct-app/flake.lock
+++ b/ct-app/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +31,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -34,10 +71,33 @@
         "type": "github"
       }
     },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit": "pre-commit"
       }
     },
     "systems": {

--- a/ct-app/flake.nix
+++ b/ct-app/flake.nix
@@ -21,26 +21,6 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
-        # Override uv to use version 0.9.5 (supports Python 3.14) to match Dockerfile
-        # This properly builds uv for NixOS with correct library paths
-        uv-latest = pkgs.uv.overrideAttrs (oldAttrs: rec {
-          version = "0.9.5";
-
-          src = pkgs.fetchFromGitHub {
-            owner = "astral-sh";
-            repo = "uv";
-            rev = version;
-            hash = "sha256-Js62zaO44/gXCCwji4LmlyO62zI96CFhnfnYqgI2p+U=";
-          };
-
-          # Let Nix re-fetch cargo dependencies for the new version
-          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-            inherit src;
-            name = "uv-${version}-vendor";
-            hash = "sha256-TadS0YrZV5psCcGiu21w55nQhlzU+gXZPmFCAONLbXE=";
-          };
-        });
-
         dockerBuild = pkgs.writeShellApplication {
           name = "dockerBuild";
           runtimeInputs = [
@@ -98,7 +78,7 @@
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
             python314 # Python 3.14 to match Dockerfile
-            uv-latest # uv 0.9.5 to match Dockerfile
+            uv # supports Python 3.14
             ruff # Python linter and formatter
           ];
 

--- a/ct-app/flake.nix
+++ b/ct-app/flake.nix
@@ -6,32 +6,42 @@
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
+    pre-commit.url = "github:cachix/git-hooks.nix";
+    pre-commit.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      pre-commit,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
 
-      # Override uv to use version 0.9.5 (supports Python 3.14) to match Dockerfile
-      # This properly builds uv for NixOS with correct library paths
-      uv-latest = pkgs.uv.overrideAttrs (oldAttrs: rec {
-        version = "0.9.5";
+        # Override uv to use version 0.9.5 (supports Python 3.14) to match Dockerfile
+        # This properly builds uv for NixOS with correct library paths
+        uv-latest = pkgs.uv.overrideAttrs (oldAttrs: rec {
+          version = "0.9.5";
 
-        src = pkgs.fetchFromGitHub {
-          owner = "astral-sh";
-          repo = "uv";
-          rev = version;
-          hash = "sha256-Js62zaO44/gXCCwji4LmlyO62zI96CFhnfnYqgI2p+U=";
-        };
+          src = pkgs.fetchFromGitHub {
+            owner = "astral-sh";
+            repo = "uv";
+            rev = version;
+            hash = "sha256-Js62zaO44/gXCCwji4LmlyO62zI96CFhnfnYqgI2p+U=";
+          };
 
-        # Let Nix re-fetch cargo dependencies for the new version
-        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-          inherit src;
-          name = "uv-${version}-vendor";
-          hash = "sha256-TadS0YrZV5psCcGiu21w55nQhlzU+gXZPmFCAONLbXE=";
-        };
-      });
+          # Let Nix re-fetch cargo dependencies for the new version
+          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+            inherit src;
+            name = "uv-${version}-vendor";
+            hash = "sha256-TadS0YrZV5psCcGiu21w55nQhlzU+gXZPmFCAONLbXE=";
+          };
+        });
 
-      dockerBuild = pkgs.writeShellApplication {
+        dockerBuild = pkgs.writeShellApplication {
           name = "dockerBuild";
           runtimeInputs = [
             pkgs.docker
@@ -47,40 +57,79 @@
           '';
         };
 
-    in rec {
-      devShells.ci = pkgs.mkShell {
-        packages = [ pkgs.zizmor ];
-      };
-
-      devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          python314    # Python 3.14 to match Dockerfile
-          uv-latest    # uv 0.9.5 to match Dockerfile
-          ruff         # Python linter and formatter
-        ];
-
-        shellHook = ''
-          echo "Development environment loaded:"
-          echo "  Python: $(python3 --version)"
-          echo "  uv: $(uv --version)"
-          echo "  uvx: $(uvx --version)"
-          echo "  ruff: $(ruff --version)"
-          echo ""
-          uv sync
-        '';
-      };
-
-      # Define flake apps
-      apps = {
-        docker-x86_64-linux = {
-          type = "app";
-          program = "${dockerBuild}/bin/dockerBuild";
+        pre-commit-check = pre-commit.lib.${system}.run {
+          src = ../.;
+          hooks = {
+            check-executables-have-shebangs.enable = true;
+            check-shebang-scripts-are-executable.enable = true;
+            check-case-conflicts.enable = true;
+            check-symlinks.enable = true;
+            check-merge-conflicts.enable = true;
+            check-added-large-files.enable = true;
+            commitizen.enable = true;
+            actionlint.enable = true;
+            pinact = {
+              enable = true;
+              name = "pinact";
+              description = "Check GitHub Action refs are SHA-pinned and resolvable";
+              entry = "${pkgs.writeShellScript "pinact-check" ''
+                token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                if [ -z "$token" ]; then
+                  echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                  exit 0
+                fi
+                export GITHUB_TOKEN="$token"
+                exec ${pkgs.pinact}/bin/pinact run --check
+              ''}";
+              files = "\\.ya?ml$";
+              language = "system";
+              pass_filenames = false;
+            };
+          };
+          tools = pkgs;
         };
-        default = {
-          type = "app";
-          program = "${dockerBuild}/bin/dockerBuild";
+
+      in
+      rec {
+        devShells.ci = pkgs.mkShell {
+          packages = [ pkgs.zizmor ];
         };
-      };
-    }
-  );
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python314 # Python 3.14 to match Dockerfile
+            uv-latest # uv 0.9.5 to match Dockerfile
+            ruff # Python linter and formatter
+          ];
+
+          shellHook = ''
+            echo "Development environment loaded:"
+            echo "  Python: $(python3 --version)"
+            echo "  uv: $(uv --version)"
+            echo "  uvx: $(uvx --version)"
+            echo "  ruff: $(ruff --version)"
+            echo ""
+            uv sync
+            ${pre-commit-check.shellHook}
+            export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+          '';
+        };
+
+        packages = {
+          inherit pre-commit-check;
+        };
+
+        # Define flake apps
+        apps = {
+          docker-x86_64-linux = {
+            type = "app";
+            program = "${dockerBuild}/bin/dockerBuild";
+          };
+          default = {
+            type = "app";
+            program = "${dockerBuild}/bin/dockerBuild";
+          };
+        };
+      }
+    );
 }

--- a/ct-app/flake.nix
+++ b/ct-app/flake.nix
@@ -111,7 +111,9 @@
             echo ""
             uv sync
             ${pre-commit-check.shellHook}
-            export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+            if [ -z "''${GITHUB_TOKEN:-}" ]; then
+              export GITHUB_TOKEN="$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)"
+            fi
           '';
         };
 


### PR DESCRIPTION
## Summary

- Pins all `hoprnet/hopr-workflows` action/workflow refs to new OIDC-enabled SHAs
- Removes legacy `gcp_service_account`, `google_credentials`, and `GH_RUNNER_TOKEN` PAT from workflow inputs
- Adds `id-token: write` permission to every consumer job for OIDC token minting
- Adds `github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}` to all `release-version` invocations
- Bumps all `hopr-workflows` refs to `0.11.0` (`5b0f0e6`) and `setup-nix` to `setup-nix-v2` (`5477bd5`)
- Drops custom `uv 0.9.5` Nix override; uses `pkgs.uv` from nixpkgs directly (0.11.19) to fix CI build failure caused by crates.io 403-ing depot.dev runner IPs during `fetchCargoVendor`

Part of the org-wide WIF migration following the GitHub security incident. Reference: hoprnet/blokli#377