### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/ct-app/flake.lock
+++ b/ct-app/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +31,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -34,10 +71,33 @@
         "type": "github"
       }
     },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit": "pre-commit"
       }
     },
     "systems": {

--- a/ct-app/flake.nix
+++ b/ct-app/flake.nix
@@ -6,32 +6,42 @@
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
+    pre-commit.url = "github:cachix/git-hooks.nix";
+    pre-commit.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      pre-commit,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
 
-      # Override uv to use version 0.9.5 (supports Python 3.14) to match Dockerfile
-      # This properly builds uv for NixOS with correct library paths
-      uv-latest = pkgs.uv.overrideAttrs (oldAttrs: rec {
-        version = "0.9.5";
+        # Override uv to use version 0.9.5 (supports Python 3.14) to match Dockerfile
+        # This properly builds uv for NixOS with correct library paths
+        uv-latest = pkgs.uv.overrideAttrs (oldAttrs: rec {
+          version = "0.9.5";
 
-        src = pkgs.fetchFromGitHub {
-          owner = "astral-sh";
-          repo = "uv";
-          rev = version;
-          hash = "sha256-Js62zaO44/gXCCwji4LmlyO62zI96CFhnfnYqgI2p+U=";
-        };
+          src = pkgs.fetchFromGitHub {
+            owner = "astral-sh";
+            repo = "uv";
+            rev = version;
+            hash = "sha256-Js62zaO44/gXCCwji4LmlyO62zI96CFhnfnYqgI2p+U=";
+          };
 
-        # Let Nix re-fetch cargo dependencies for the new version
-        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-          inherit src;
-          name = "uv-${version}-vendor";
-          hash = "sha256-TadS0YrZV5psCcGiu21w55nQhlzU+gXZPmFCAONLbXE=";
-        };
-      });
+          # Let Nix re-fetch cargo dependencies for the new version
+          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+            inherit src;
+            name = "uv-${version}-vendor";
+            hash = "sha256-TadS0YrZV5psCcGiu21w55nQhlzU+gXZPmFCAONLbXE=";
+          };
+        });
 
-      dockerBuild = pkgs.writeShellApplication {
+        dockerBuild = pkgs.writeShellApplication {
           name = "dockerBuild";
           runtimeInputs = [
             pkgs.docker
@@ -47,40 +57,71 @@
           '';
         };
 
-    in rec {
-      devShells.ci = pkgs.mkShell {
-        packages = [ pkgs.zizmor ];
-      };
-
-      devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          python314    # Python 3.14 to match Dockerfile
-          uv-latest    # uv 0.9.5 to match Dockerfile
-          ruff         # Python linter and formatter
-        ];
-
-        shellHook = ''
-          echo "Development environment loaded:"
-          echo "  Python: $(python3 --version)"
-          echo "  uv: $(uv --version)"
-          echo "  uvx: $(uvx --version)"
-          echo "  ruff: $(ruff --version)"
-          echo ""
-          uv sync
-        '';
-      };
-
-      # Define flake apps
-      apps = {
-        docker-x86_64-linux = {
-          type = "app";
-          program = "${dockerBuild}/bin/dockerBuild";
+        pre-commit-check = pre-commit.lib.${system}.run {
+          src = ../.;
+          hooks = {
+            check-executables-have-shebangs.enable = true;
+            check-shebang-scripts-are-executable.enable = true;
+            check-case-conflicts.enable = true;
+            check-symlinks.enable = true;
+            check-merge-conflicts.enable = true;
+            check-added-large-files.enable = true;
+            commitizen.enable = true;
+            actionlint.enable = true;
+            pinact = {
+              enable = true;
+              name = "pinact";
+              description = "Check GitHub Action refs are SHA-pinned and resolvable";
+              entry = "${pkgs.pinact}/bin/pinact run --check";
+              files = "\\.ya?ml$";
+              language = "system";
+              pass_filenames = false;
+            };
+          };
+          tools = pkgs;
         };
-        default = {
-          type = "app";
-          program = "${dockerBuild}/bin/dockerBuild";
+
+      in
+      rec {
+        devShells.ci = pkgs.mkShell {
+          packages = [ pkgs.zizmor ];
         };
-      };
-    }
-  );
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python314 # Python 3.14 to match Dockerfile
+            uv-latest # uv 0.9.5 to match Dockerfile
+            ruff # Python linter and formatter
+          ];
+
+          shellHook = ''
+            echo "Development environment loaded:"
+            echo "  Python: $(python3 --version)"
+            echo "  uv: $(uv --version)"
+            echo "  uvx: $(uvx --version)"
+            echo "  ruff: $(ruff --version)"
+            echo ""
+            uv sync
+            ${pre-commit-check.shellHook}
+            export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+          '';
+        };
+
+        packages = {
+          inherit pre-commit-check;
+        };
+
+        # Define flake apps
+        apps = {
+          docker-x86_64-linux = {
+            type = "app";
+            program = "${dockerBuild}/bin/dockerBuild";
+          };
+          default = {
+            type = "app";
+            program = "${dockerBuild}/bin/dockerBuild";
+          };
+        };
+      }
+    );
 }

--- a/ct-app/flake.nix
+++ b/ct-app/flake.nix
@@ -72,7 +72,15 @@
               enable = true;
               name = "pinact";
               description = "Check GitHub Action refs are SHA-pinned and resolvable";
-              entry = "${pkgs.pinact}/bin/pinact run --check";
+              entry = "${pkgs.writeShellScript "pinact-check" ''
+                token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                if [ -z "$token" ]; then
+                  echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                  exit 0
+                fi
+                export GITHUB_TOKEN="$token"
+                exec ${pkgs.pinact}/bin/pinact run --check
+              ''}";
               files = "\\.ya?ml$";
               language = "system";
               pass_filenames = false;


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake. Depends on: WIF migration PR must merge first so pinact --check passes on the hopr-workflows refs.